### PR TITLE
Split agent reply timeout from execution timeout

### DIFF
--- a/lib/mcollective/agents.rb
+++ b/lib/mcollective/agents.rb
@@ -122,9 +122,12 @@ module MCollective
         begin
           agent = PluginManager["#{request.agent}_agent"]
 
+          replies = nil
           Timeout::timeout(agent.timeout) do
             replies = agent.handlemsg(request.payload, connection)
+          end
 
+          Timeout::timeout(@config.agent_reply_timeout) do
             # Agents can decide if they wish to reply or not,
             # returning nil will mean nothing goes back to the
             # requestor

--- a/lib/mcollective/config.rb
+++ b/lib/mcollective/config.rb
@@ -15,7 +15,7 @@ module MCollective
     attr_reader :main_collective, :ssl_cipher, :registration_collective
     attr_reader :direct_addressing, :direct_addressing_threshold, :ttl
     attr_reader :default_discovery_method, :default_discovery_options
-    attr_reader :publish_timeout, :threaded
+    attr_reader :publish_timeout, :threaded, :agent_reply_timeout
 
     def initialize
       @configured = false
@@ -115,6 +115,8 @@ module MCollective
                   @default_discovery_method = val
                 when "topicprefix", "topicsep", "queueprefix", "rpchelptemplate", "helptemplatedir"
                   Log.warn("Use of deprecated '#{key}' option.  This option is ignored and should be removed from '#{configfile}'")
+                when "agent_reply_timeout"
+                  @agent_reply_timeout = Integer(val)
                 else
                   raise("Unknown config parameter '#{key}'")
                 end
@@ -190,6 +192,7 @@ module MCollective
       @mode = :client
       @publish_timeout = 2
       @threaded = false
+      @agent_reply_timeout = 30
     end
 
     def read_plugin_config_dir(dir)

--- a/lib/mcollective/optionparser.rb
+++ b/lib/mcollective/optionparser.rb
@@ -174,6 +174,10 @@ module MCollective
         @options[:publish_timeout] = pt
       end
 
+      @parser.on("--agent_reply_timeout TIMEOUT", Integer, "Timeout for publishing replies from agent actions to remote callers.") do |pt|
+        @options[:agent_reply_timeout] = pt
+      end
+
       @parser.on("--threaded", "Start publishing requests and receiving responses in threaded mode.") do |v|
         @options[:threaded] = true
       end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -118,7 +118,7 @@ module MCollective
         PluginManager.stubs("<<")
 
         ["registerinterval", "max_log_size", "direct_addressing_threshold", "publish_timeout",
-         "fact_cache_time", "ttl"].each do |key|
+         "fact_cache_time", "ttl", "agent_reply_timeout"].each do |key|
           File.expects(:readlines).with("/nonexisting").returns(["#{key} = nan"])
           File.expects(:exists?).with("/nonexisting").returns(true)
 

--- a/spec/unit/optionparser_spec.rb
+++ b/spec/unit/optionparser_spec.rb
@@ -175,6 +175,12 @@ module MCollective
         @parser.instance_variable_get(:@options)[:publish_timeout].should == 5
       end
 
+      it 'should parse the --agent_reply_timeout option' do
+        ARGV << '--agent_reply_timeout=5'
+        @parser.parse
+        @parser.instance_variable_get(:@options)[:agent_reply_timeout].should == 5
+      end
+
       it 'should parse the --threaded option' do
         ARGV << '--threaded'
         @parser.parse


### PR DESCRIPTION
If the agent's action times out in the middle of sending a reply, it may
send a partial message over the wire, which can lead to errors in the
messaging broker.

Run the agent's action in its own timeout block, and if it finishes,
yield the replies in a separate timeout block. This way, it should be
less likely that a partial message is sent out over the wire.