### PR TITLE
(MCO-386) MCO README.md should express semver

### DIFF
--- a/README
+++ b/README
@@ -4,3 +4,24 @@ The Marionette Collective
 The Marionette Collective aka. mcollective is a framework to build server orchestration or parallel job execution systems.
 
 For full information, wikis, ticketing and downloads please see http://marionette-collective.org/
+
+
+Support
+=======
+We use semantic version numbers for our releases, and recommend that users stay
+as up-to-date as possible by upgrading to patch releases and minor releases as
+they become available.
+
+Bugfixes and ongoing development will occur in minor releases for the current
+major version. Security fixes will be backported to a previous major version on
+a best-effort basis, until the previous major version is no longer maintained.
+
+
+For example: If a security vulnerability is discovered in Mcollective 2.5.3, we
+would fix it in the 2 series, most likely as 2.5.4. Maintainers would then make
+a best effort to backport that fix onto their latest supported release.
+
+Long-term support, including security patches and bug fixes, is available for
+commercial customers. Please see the following page for more details:
+
+[Puppet Enterprise Support Lifecycle](http://puppetlabs.com/misc/puppet-enterprise-lifecycle)


### PR DESCRIPTION
The puppet readme (https://github.com/puppetlabs/puppet/blob/master/README.md)
explains the maintenance we have for versions of puppet and that it is
semantically versioned. We recently encountered an issue with Facter where
users were surprised that we did not ship a security release for a previous
major version of facter. The previous assumption may have been that the puppet
README was sufficient for all of our FOSS projects, but this is probably not
the case. We should update the README.md in mcollective with the same verbage as
puppet so our intended release lifecycle is clear.

Signed-off-by: Moses Mendoza <moses@puppetlabs.com>