### PR TITLE
MCO-519 rake rubocop should indicate success via exitcode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'ext/packaging/**/*'
     - 'spec/**/*'
     - 'tasks/**/*'
+    - 'lib/mcollective/vendor/**/*'
 
 Lint/ConditionPosition:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Lint/AmbiguousOperator:
 Lint/AssignmentInCondition:
   Enabled: false
 
+Metrics/AbcSize:
+  Enabled: false
+
 Metrics/BlockNesting:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -369,6 +369,9 @@ Style/TrailingWhitespace:
 Style/StringLiterals:
   Enabled: false
 
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+
 Style/TrailingComma:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,8 @@ Lint/ShadowingOuterLocalVariable:
 Lint/LiteralInInterpolation:
   Enabled: true
 
+Style/EmptyElse:
+  Enabled: false
 
 # DISABLED really useless. Detects return as last statement.
 Style/RedundantReturn:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -336,7 +336,16 @@ Style/EmptyLines:
 Style/EmptyLinesAroundAccessModifier:
   Enabled: false
 
-Style/EmptyLinesAroundBody:
+Style/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+Style/EmptyLinesAroundMethodBody:
+  Enabled: false
+
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Style/EmptyLinesAroundModuleBody:
   Enabled: false
 
 Style/EmptyLiteral:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'systemu'
 
 group :dev do
   gem 'rake'
-  gem "rubocop", :platforms => [:ruby] unless RUBY_VERSION =~ /^1.8/
+  gem 'rubocop', '~> 0.28.0', :platforms => [:ruby] unless RUBY_VERSION =~ /^1.8/
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -113,7 +113,7 @@ task(:rubocop) do
   if RUBY_VERSION !~ /1.8/
     require 'rubocop'
     cli = RuboCop::CLI.new
-    cli.run(%w(-D -f s))
+    exit cli.run(%w(-D -f s))
   else
     puts "Rubocop is disabled in ruby 1.8"
   end

--- a/lib/mcollective/matcher/scanner.rb
+++ b/lib/mcollective/matcher/scanner.rb
@@ -152,7 +152,7 @@ module MCollective
         else
           if func
             if current_token_value.match(/^.+?\((\s*(')[^']*(')\s*(,\s*(')[^']*('))*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/) ||
-              current_token_value.match(/^.+?\((\s*(")[^"]*(")\s*(,\s*(")[^"]*("))*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/)
+               current_token_value.match(/^.+?\((\s*(")[^"]*(")\s*(,\s*(")[^"]*("))*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/)
               return "fstatement", current_token_value
             else
               return "bad_token", [@token_index - current_token_value.size + 1, @token_index]

--- a/plugins/mcollective/application/plugin.rb
+++ b/plugins/mcollective/application/plugin.rb
@@ -333,8 +333,7 @@ mco plugin package [options] <directory>
     # Return the name of the type of plugin as a string
     def identify_plugin
       plugintype = Dir.glob(File.join(configuration[:target], "*")).select do |file|
-        File.directory?(file) &&
-          file.match(/(connector|facts|registration|security|audit|pluginpackager|data|discovery|validator)/)
+        File.directory?(file) && file.match(/(connector|facts|registration|security|audit|pluginpackager|data|discovery|validator)/)
       end
 
       raise RuntimeError, "more than one plugin type detected in directory" if plugintype.size > 1


### PR DESCRIPTION
Here we:

Make the exitcode of `rake rubocop` meaningful
Pin rubocop to 0.28.x
Update rules/exceptions to handle the newer cops in rubocop 0.28