### PR TITLE
Update logfile path for AIO agent layout, add logrotate and sysconfig files.

### DIFF
--- a/etc/server.cfg.dist
+++ b/etc/server.cfg.dist
@@ -1,7 +1,7 @@
 main_collective = mcollective
 collectives = mcollective
 libdir = /usr/libexec/mcollective
-logfile = /var/log/mcollective.log
+logfile = /var/log/puppetlabs/agent/mcollective.log
 loglevel = info
 daemonize = 1
 

--- a/ext/activemq/apache-activemq.spec
+++ b/ext/activemq/apache-activemq.spec
@@ -50,7 +50,7 @@ install --directory ${RPM_BUILD_ROOT}%{libexecdir}
 install --directory ${RPM_BUILD_ROOT}%{libdir}/webapps
 install --directory ${RPM_BUILD_ROOT}%{cachedir}
 install --directory ${RPM_BUILD_ROOT}%{cachedir}/data
-install --directory ${RPM_BUILD_ROOT}/var/log/%{name}
+install --directory ${RPM_BUILD_ROOT}/var/log/puppetlabs/agent/%{name}
 install --directory ${RPM_BUILD_ROOT}/var/run/%{name}
 install --directory ${RPM_BUILD_ROOT}/etc/%{name}
 install --directory ${RPM_BUILD_ROOT}/etc/init.d
@@ -88,7 +88,7 @@ pushd ${RPM_BUILD_ROOT}%{homedir}
     [ -d docs ] || %{__ln_s} -f %{docsdir} docs
     [ -d lib ] || %{__ln_s} -f %{libdir}/lib lib
     [ -d lib ] || %{__ln_s} -f %{libdir}/libexec libexec
-    [ -d log ] || %{__ln_s} -f /var/log/%{name} log 
+    [ -d log ] || %{__ln_s} -f /var/log/puppetlabs/agent/%{name} log
     [ -d webapps ] || %{__ln_s} -f %{libdir}/webapps webapps
 popd
 
@@ -123,7 +123,7 @@ rm -rf $RPM_BUILD_ROOT
 %docdir %{docsdir}
 %{docsdir}
 %{libdir}
-%attr(775,activemq,activemq) %dir /var/log/%{name}
+%attr(775,activemq,activemq) %dir /var/log/puppetlabs/agent/%{name}
 %attr(775,activemq,activemq) %dir /var/run/%{name}
 %attr(775,root,activemq) %dir %{cachedir}/data
 %attr(755,root,root) /etc/init.d/activemq

--- a/ext/debian/mcollective.default
+++ b/ext/debian/mcollective.default
@@ -1,0 +1,2 @@
+START=true
+DAEMON_OPTS="--pid ${PIDFILE}"

--- a/ext/debian/patches/pluginsdir.patch
+++ b/ext/debian/patches/pluginsdir.patch
@@ -19,6 +19,6 @@ index 2038324..c28a826 100644
  collectives = mcollective
 -libdir = /usr/libexec/mcollective
 +libdir = /usr/share/mcollective/plugins
- logfile = /var/log/mcollective.log
+ logfile = /var/log/puppetlabs/agent/mcollective.log
  loglevel = info
  daemonize = 1

--- a/ext/openbsd/port-files/mcollective/patches/patch-etc_server_cfg_dist
+++ b/ext/openbsd/port-files/mcollective/patches/patch-etc_server_cfg_dist
@@ -4,6 +4,6 @@ $OpenBSD$
 @@ -1,5 +1,5 @@
 -libdir = /usr/libexec/mcollective
 +libdir = ${PREFIX}/share/mcollective/plugins
- logfile = /var/log/mcollective.log
+ logfile = /var/log/puppetlabs/agent/mcollective.log
  loglevel = info
  daemonize = 1

--- a/ext/osx/bldmacpkg
+++ b/ext/osx/bldmacpkg
@@ -7,7 +7,7 @@ BBINDIR='/usr/bin'
 BLIBEXECDIR='/usr/libexec/mcollective'
 BDOCDIR='/usr/share/doc/mcollective'
 BLAUNCHDIR='/Library/LaunchDaemons'
-BLOGDIR='/var/log/mcollective'
+BLOGDIR='/var/log/puppetlabs/agent'
 PACKAGEMAKER='/Applications/PackageMaker.app/Contents/MacOS/PackageMaker'
 
 if [ -z $MPATH ]; then

--- a/ext/redhat/mcollective-systemd.logrotate
+++ b/ext/redhat/mcollective-systemd.logrotate
@@ -1,4 +1,4 @@
-/var/log/mcollective/*log {
+/var/log/puppetlabs/agent/mcollective.log {
     missingok
     notifempty
     sharedscripts

--- a/ext/redhat/mcollective-systemd.logrotate
+++ b/ext/redhat/mcollective-systemd.logrotate
@@ -1,0 +1,8 @@
+/var/log/mcollective/*log {
+    missingok
+    notifempty
+    sharedscripts
+    postrotate
+      /usr/bin/systemctl restart mcollective >/dev/null 2>&1 || true
+    endscript
+}

--- a/ext/redhat/mcollective-sysv.logrotate
+++ b/ext/redhat/mcollective-sysv.logrotate
@@ -1,4 +1,4 @@
-/var/log/mcollective/*log {
+/var/log/puppetlabs/agent/mcollective.log {
     missingok
     notifempty
     sharedscripts

--- a/ext/redhat/mcollective-sysv.logrotate
+++ b/ext/redhat/mcollective-sysv.logrotate
@@ -1,0 +1,8 @@
+/var/log/mcollective/*log {
+    missingok
+    notifempty
+    sharedscripts
+    postrotate
+        /etc/init.d/mcollective restart >/dev/null 2>&1 || true
+    endscript
+}

--- a/ext/redhat/mcollective.sysconfig
+++ b/ext/redhat/mcollective.sysconfig
@@ -1,0 +1,10 @@
+# Configuration file for mcollectived
+
+# Full path to the mcollectived binary
+#DAEMON=/opt/puppetlabs/agent/bin/mcollectived
+
+# Location of PID file
+#PIDFILE=/var/run/mcollectived.pid
+
+# Any other parameters to pass to mcollectived
+#DAEMON_OPTS=

--- a/plugins/mcollective/audit/logfile.rb
+++ b/plugins/mcollective/audit/logfile.rb
@@ -10,7 +10,7 @@ module MCollective
       require 'pp'
 
       def audit_request(request, connection)
-        logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/mcollective-audit.log"
+        logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/puppetlabs/agent/mcollective-audit.log"
 
         now = Time.now
         # Already told timezone to be in UTC so we don't look it up again

--- a/spec/unit/plugins/mcollective/audit/logfile_spec.rb
+++ b/spec/unit/plugins/mcollective/audit/logfile_spec.rb
@@ -36,7 +36,7 @@ module MCollective
 
       it 'should log to a default logfile' do
         Config.any_instance.stubs(:pluginconf).returns({})
-        File.expects(:open).with("/var/log/mcollective-audit.log", "a").yields(file)
+        File.expects(:open).with("/var/log/puppetlabs/agent/mcollective-audit.log", "a").yields(file)
         Logfile.new.audit_request(request, nil)
       end
     end

--- a/website/configure/client.md
+++ b/website/configure/client.md
@@ -109,7 +109,7 @@ plugin.psk = j9q8kx7fnuied9e
 
 <a href="#loggertype">logger_type</a> = console
 <a href="#loglevel">loglevel</a> = warn
-<a href="#logfile">logfile</a> = /var/log/mcollective.log
+<a href="#logfile">logfile</a> = /var/log/puppetlabs/agent/mcollective.log
 <a href="#keeplogs">keeplogs</a> = 5
 <a href="#maxlogsize">max_log_size</a> = 2097152
 <a href="#logfacility">logfacility</a> = user
@@ -505,7 +505,7 @@ These settings can generally be ignored, as appropriate values should have been 
 
 <pre><code><a href="#loggertype">logger_type</a> = console
 <a href="#loglevel">loglevel</a> = warn
-<a href="#logfile">logfile</a> = /var/log/mcollective.log
+<a href="#logfile">logfile</a> = /var/log/puppetlabs/agent/mcollective.log
 <a href="#keeplogs">keeplogs</a> = 5
 <a href="#maxlogsize">max_log_size</a> = 2097152
 <a href="#logfacility">logfacility</a> = user
@@ -537,7 +537,7 @@ _When `logger_type == file`_
 Where the log file should be stored.
 
 - _Default:_ (nothing; the package's default config file usually sets a platform-appropriate value)
-- _Sample value:_ `/var/log/mcollective.log`
+- _Sample value:_ `/var/log/puppetlabs/agent/mcollective.log`
 
 #### `keeplogs`
 

--- a/website/configure/server.md
+++ b/website/configure/server.md
@@ -114,7 +114,7 @@ plugin.psk = j9q8kx7fnuied9e
 
 <a href="#rpcaudit">rpcaudit</a> = 1
 <a href="#rpcauditprovider">rpcauditprovider</a> = logfile
-<a href="#pluginrpcauditlogfile">plugin.rpcaudit.logfile</a> = /var/log/mcollective-audit.log
+<a href="#pluginrpcauditlogfile">plugin.rpcaudit.logfile</a> = /var/log/puppetlabs/agent/mcollective-audit.log
 
 # <a href="#authorization">Authorization (optional):</a>
 # ------------------------
@@ -127,7 +127,7 @@ plugin.psk = j9q8kx7fnuied9e
 
 <a href="#loggertype">logger_type</a> = file
 <a href="#loglevel">loglevel</a> = info
-<a href="#logfile">logfile</a> = /var/log/mcollective.log
+<a href="#logfile">logfile</a> = /var/log/puppetlabs/agent/mcollective.log
 <a href="#keeplogs">keeplogs</a> = 5
 <a href="#maxlogsize">max_log_size</a> = 2097152
 <a href="#logfacility">logfacility</a> = user
@@ -594,7 +594,7 @@ The main collective for this server. Currently, this is only used as the default
 
 <pre><code><a href="#rpcaudit">rpcaudit</a> = 1
 <a href="#rpcauditprovider">rpcauditprovider</a> = logfile
-<a href="#pluginrpcauditlogfile">plugin.rpcaudit.logfile</a> = /var/log/mcollective-audit.log
+<a href="#pluginrpcauditlogfile">plugin.rpcaudit.logfile</a> = /var/log/puppetlabs/agent/mcollective-audit.log
 </code>
 </pre>
 
@@ -629,7 +629,7 @@ _When `rpcauditprovider == logfile`_
 
 The file to write to when using the `logfile` audit plugin. **Note:** this file is not automatically rotated.
 
-- _Default:_ `/var/log/mcollective-audit.log`
+- _Default:_ `/var/log/puppetlabs/agent/mcollective-audit.log`
 
 
 ([↑ Back to top](#content))
@@ -674,7 +674,7 @@ Advanced Settings
 
 <pre><code><a href="#loggertype">logger_type</a> = file
 <a href="#loglevel">loglevel</a> = info
-<a href="#logfile">logfile</a> = /var/log/mcollective.log
+<a href="#logfile">logfile</a> = /var/log/puppetlabs/agent/mcollective.log
 <a href="#keeplogs">keeplogs</a> = 5
 <a href="#maxlogsize">max_log_size</a> = 2097152
 <a href="#logfacility">logfacility</a> = user
@@ -706,7 +706,7 @@ _When `logger_type == file`_
 Where the log file should be stored.
 
 - _Default:_ (nothing; the package's default config file usually sets a platform-appropriate value)
-- _Sample value:_ `/var/log/mcollective.log`
+- _Sample value:_ `/var/log/puppetlabs/agent/mcollective.log`
 
 #### `keeplogs`
 

--- a/website/deploy/standard.md
+++ b/website/deploy/standard.md
@@ -329,7 +329,7 @@ This example template snippet shows the settings you need to use in a standard d
     # If you turn this on, you must arrange to rotate the log file it creates.
     rpcaudit = 1
     rpcauditprovider = logfile
-    plugin.rpcaudit.logfile = /var/log/mcollective-audit.log
+    plugin.rpcaudit.logfile = /var/log/puppetlabs/agent/mcollective-audit.log
 
     # Authorization:
     # If you turn this on now, you won't be able to issue most MCollective
@@ -343,7 +343,7 @@ This example template snippet shows the settings you need to use in a standard d
     # Logging:
     logger_type = file
     loglevel = info
-    logfile = /var/log/mcollective.log
+    logfile = /var/log/puppetlabs/agent/mcollective.log
     keeplogs = 5
     max_log_size = 2097152
     logfacility = user

--- a/website/reference/basic/configuration.md
+++ b/website/reference/basic/configuration.md
@@ -27,7 +27,7 @@ Configuration is a simple *key = val* style configuration file.
 |---|------|-----------|
 |collectives|mcollective,subcollective|A list of [Subcollectives][] to join - 1.1.3 and newer only|
 |main_collective|mcollective|The main collective to target - 1.1.3 and newer only|
-|logfile|/var/log/mcollective.log|Where to log|
+|logfile|/var/log/puppetlabs/agent/mcollective.log|Where to log|
 |loglevel|debug|Can be info, warn, debug, fatal, error|
 |identity|dev1.your.com|Identifier for this node, does not need to be unique, defaults to hostname if unset and must match _/\w\.\-/_ if set|
 |keeplogs|5|The amount of logs to keep|

--- a/website/reference/basic/gettingstarted_debian.md
+++ b/website/reference/basic/gettingstarted_debian.md
@@ -156,7 +156,7 @@ You should also create _/etc/mcollective/server.cfg_ here's a sample, a full ref
 {% highlight ini %}
   # main config
   libdir = /usr/libexec/mcollective
-  logfile = /var/log/mcollective.log
+  logfile = /var/log/puppetlabs/agent/mcollective.log
   daemonize = 1
   loglevel = info
 
@@ -202,7 +202,7 @@ The packages include standard init script, just start the server:
 You should see in the log file somethig like:
 
 {% highlight console %}
-  # tail /var/log/mcollective.log
+  # tail /var/log/puppetlabs/agent/mcollective.log
   I, [2010-12-29T11:15:32.321744 #11479]  INFO -- : mcollectived:33 The Marionette Collective 1.1.0 started logging at info level
 {% endhighlight %}
 

--- a/website/reference/basic/gettingstarted_redhat.md
+++ b/website/reference/basic/gettingstarted_redhat.md
@@ -153,7 +153,7 @@ You should also create _/etc/mcollective/server.cfg_ here's a sample, a full ref
 {% highlight ini %}
   # main config
   libdir = /usr/libexec/mcollective
-  logfile = /var/log/mcollective.log
+  logfile = /var/log/puppetlabs/agent/mcollective.log
   daemonize = 1
   loglevel = info
 
@@ -198,7 +198,7 @@ The packages include standard init script, just start the server:
 You should see in the log file somethig like:
 
 {% highlight console %}
-  # tail /var/log/mcollective.log
+  # tail /var/log/puppetlabs/agent/mcollective.log
   I, [2010-12-29T11:15:32.321744 #11479]  INFO -- : mcollectived:33 The Marionette Collective 1.1.0 started logging at info level
 {% endhighlight %}
 

--- a/website/simplerpc/auditing.md
+++ b/website/simplerpc/auditing.md
@@ -35,7 +35,7 @@ module MCollective
 	    require 'pp'
 
             def audit_request(request, connection)
-                logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/mcollective-audit.log"
+                logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/puppetlabs/agent/mcollective-audit.log"
 
                 now = Time.now
                 now_tz = tz = now.utc? ? "Z" : now.strftime("%z")
@@ -55,7 +55,7 @@ As you can see you only need to provide one method called _audit_request_, you w
 The Logfile plugin takes a configuration option:
 
 {% highlight ini %}
-plugin.rpcaudit.logfile = /var/log/mcollective-audit.log
+plugin.rpcaudit.logfile = /var/log/puppetlabs/agent/mcollective-audit.log
 {% endhighlight %}
 
 We do not do log rotation of this file so you should do that yourself if you enable this plugin.


### PR DESCRIPTION
In preparation for the transition to the AIO agent,
this changeset updates the logfile path to the unified
agent layout and adds logrotate and sysconfig
files derived from the PE mcollective fork.