### PR TITLE
MCO-558 `mco facts` stacktrace with no found fact

### DIFF
--- a/plugins/mcollective/application/facts.rb
+++ b/plugins/mcollective/application/facts.rb
@@ -45,7 +45,11 @@ class MCollective::Application::Facts<MCollective::Application
       end
     end
 
-    show_single_fact_report(configuration[:fact], facts, options[:verbose])
+    if facts.empty?
+      puts "No values found for fact #{configuration[:fact]}\n"
+    else
+      show_single_fact_report(configuration[:fact], facts, options[:verbose])
+    end
 
     printrpcstats
 

--- a/plugins/mcollective/application/facts.rb
+++ b/plugins/mcollective/application/facts.rb
@@ -38,7 +38,11 @@ class MCollective::Application::Facts<MCollective::Application
       begin
         value = resp[:body][:data][:value]
         if value
-          facts.include?(value) ? facts[value] << resp[:senderid] : facts[value] = [ resp[:senderid] ]
+          if facts.include?(value)
+            facts[value] << resp[:senderid]
+          else
+            facts[value] = [ resp[:senderid] ]
+          end
         end
       rescue Exception => e
         STDERR.puts "Could not parse facts for #{resp[:senderid]}: #{e.class}: #{e}"


### PR DESCRIPTION
Here we check first to see if we have fact values to report on, before attempting to process them.