### PR TITLE
(MCO-550) Use RubyW for service

### DIFF
--- a/ext/windows/daemon.bat
+++ b/ext/windows/daemon.bat
@@ -3,4 +3,4 @@ SETLOCAL
 
 call "%~dp0..\bin\environment.bat" %0 %*
 
-ruby -rubygems "%MCOLLECTIVE_DIR%\bin\mcollectived" %*
+rubyw -rubygems "%MCOLLECTIVE_DIR%\bin\mcollectived" %*

--- a/ext/windows/service_manager.rb
+++ b/ext/windows/service_manager.rb
@@ -11,7 +11,7 @@ configfile = ENV["SERVER_CONFIG"]
 # @return [String, nil]
 def find_ruby_in_path
   ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
-    ruby = File.join(path, "ruby.exe")
+    ruby = File.join(path, "rubyw.exe")
 
     if File.exist?(ruby)
       return ruby


### PR DESCRIPTION
Previously, any powershell related functions (facter facts, providers, execs,
MCO triggered powershell commands) fail to return 0 properly, and therefore
fail, but only when triggered via the MCO daemon under windows.

Switching back to using rubyw now that bug #7239 was backported to Ruby
1.9.3 (https://bugs.ruby-lang.org/issues/9232). This allows us to take
advantage of using rubyw and providing proper exit codes for powershell
processes.