### PR TITLE
(maint) Add ci:spec task from facter/puppet/hiera

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :dev do
 end
 
 group :test do
+  gem 'yarjuf', "~> 1.0"
   gem 'rdoc'
   gem 'rspec', '~> 2.11.0'
   gem 'mocha', '~> 0.10.0'

--- a/Rakefile
+++ b/Rakefile
@@ -91,6 +91,17 @@ task :test do
   sh "cd spec && rake"
 end
 
+desc "Run spec tests"
+task :test => :spec
+
+namespace :ci do
+  desc "Run the specs with CI options"
+  task :spec do
+    ENV["LOG_SPEC_ORDER"] = "true"
+    sh %{rspec -r yarjuf -f JUnit -o result.xml -fp spec}
+  end
+end
+
 desc "Creates the website as a tarball"
 task :website => :clean do
   FileUtils.mkdir_p("build/marionette-collective.org/html")


### PR DESCRIPTION
Previously MCO didn't have a ci:spec task. This adds the one from puppet, hiera, facter.... (the ci:spec task runs the specs and leaves a junit formatted result.xml in the project root for Jenkins)