### PR TITLE
Content migration: Moves wiki plugin directory to MCO docs

### DIFF
--- a/website/plugin_directory/agent_file_manager.markdown
+++ b/website/plugin_directory/agent_file_manager.markdown
@@ -1,0 +1,7 @@
+---
+layout: normal
+title: "MCollective Plugin: File Manager Agent"
+---
+
+The documentation for this plugin can be found in its [GitHub Repository](https://github.com/puppetlabs/mcollective-filemgr-agent#readme)
+

--- a/website/plugin_directory/agent_iptables_junk_filter.markdown
+++ b/website/plugin_directory/agent_iptables_junk_filter.markdown
@@ -1,0 +1,6 @@
+---
+layout: normal
+title: "MCollective Plugin: IP Tables Junkfilter Agent"
+---
+
+The documentation for this plugin can be found in its [GitHub Repository](https://github.com/puppetlabs/mcollective-iptables-agent#readme)

--- a/website/plugin_directory/agent_metadata.markdown
+++ b/website/plugin_directory/agent_metadata.markdown
@@ -1,0 +1,7 @@
+---
+layout: normal
+title: "MCollective Plugin: Agent Metadata"
+---
+
+
+This plugin has been incorporated into MCollective core as of 2.2.0.

--- a/website/plugin_directory/agent_registration_mongodb.markdown
+++ b/website/plugin_directory/agent_registration_mongodb.markdown
@@ -1,0 +1,87 @@
+---
+layout: normal
+title: "MCollective Plugin: MongoDB Registration Agent"
+---
+
+A plugin to store data from the [registration metadata](registration_metadata.html) plugin in an instance of MongoDB as documents per node.
+
+The intention is to put all the node data in a easily reusable place for web UI's or Puppet masters to be able to access a cached snapshot of your data
+
+A prototype system exist that lets you query this data from Puppet, the code is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/registration-mongodb/puppet) and I have a [Blog Post](http://www.devco.net/archives/2010/09/18/puppet_search_engine_with_mcollective.php) that shows how it is used.
+
+Shortcomings
+=============
+
+ * It has no way to know when a node is not around anymore, so you need to delete old data yourself.  Will make scripts available that does this based on last seen time.
+
+Installation
+============
+
+You need to have the following installed:
+
+ * The [registration metadata](registration_metadata.html)  plugin and [Registration](http://docs.puppetlabs.com/mcollective/reference/plugins/registration.html) should be set up.
+ * A copy of [MongoDB](http://mongodb.org/) up and running
+ * The [Mongo Ruby](http://www.mongodb.org/display/DOCS/Ruby+Language+Center) extension
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/registration-mongodb/)
+
+Configuration
+=============
+
+<pre>
+plugin.registration.mongohost = localhost
+plugin.registration.mongodb = puppet
+plugin.registration.collection = nodes
+plugin.registration.criticalage = 3600
+</pre>
+
+With this setup you should start seeing documents show up in your mongo instance, you can verify like this:
+
+<pre>
+$ mongo
+> use puppet
+switched to db puppet
+> db.nodes.find().count()
+47
+> db.nodes.find({"fqdn": "your.box.net"})
+{ "_id" : ObjectId("4c3f7fb0dc3ecb087d000049"), "agentlist" : [
+&lt;snip&gt;
+</pre>
+
+Discovery
+======
+
+As of version 2.1.0 of MCollective discovery is pluggable, the GitHub repo for this registration receiver includes
+a discovery plugin that supports class, fact, identity and agent filters with full sub collective support.
+
+Copy the _discovery/*_ files into your client libdir and you should see them listed in the output from *mco plugin doc*:
+
+<pre>
+% mco plugin doc
+.
+.
+.
+Discovery Methods:
+  flatfile        Flatfile based discovery for node identities
+  mc              MCollective Broadcast based discovery
+  mongo           MongoDB based discovery for databases built using registration
+</pre>
+
+The discovery plugin takes the same configuration options as above to locate the mongodb instance and you can 
+set it to be the default discovery method in your client.cfg:
+
+<pre>
+default_discovery_method = mongo
+</pre>
+
+With this in place mcollective will default to discovering against this data:
+
+<pre>
+% mco rpc rpcutil ping -W country=fr
+Discovering hosts using the mongo method .... 9
+.
+.
+</pre>
+
+You can revert to the old method of discovery by passing in *--dm mc* to the client or by using any *-S* filter.
+
+It understands the criticalage configuration option and will not discover nodes that have not checked in for at least that long

--- a/website/plugin_directory/agent_registration_monitor.markdown
+++ b/website/plugin_directory/agent_registration_monitor.markdown
@@ -1,0 +1,34 @@
+---
+layout: normal
+title: "MCollective Plugin: Agent Registration Monitor"
+---
+
+MCollective supports sending [registration messages](http://docs.puppetlabs.com/mcollective/reference/plugins/registration.html) at set intervals. This is an agent to receive those messages and simply write the content to a file per sender.
+
+It includes a Nagios check that monitors the directory with these files for any that has not checked in for some time.
+
+You can use this agent as well as other types of registration agents, just not more than one per server.  So you can inventory your machines as well as monitor them on your Nagios server by just enabling registration on the mcollectived servers.
+
+Installation
+============
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/registration-monitor/).
+
+
+Configuration
+=======
+
+By default the plugin will create _/var/tmp/mcollective_ and create files in there per sender id.  
+
+You can configure the directory used using the setting _plugin.registration.directory_ in the server config.
+
+You'd install this agent in just one of your nodes and then install the included Nagios check onto the same machine.
+
+The nagios check should be invoked like:
+
+<pre>
+check_mcollective --directory /var/tmp/mcollective --interval 300
+OK: 50 / 50 hosts checked in within 300 seconds| totalhosts=50 oldhosts=0 currenthosts=50
+</pre>
+
+It includes performance data for Nagios.

--- a/website/plugin_directory/apt.markdown
+++ b/website/plugin_directory/apt.markdown
@@ -1,0 +1,66 @@
+---
+layout: normal
+title: "MCollective Plugin: AgentApt"
+---
+
+Introduction
+------------
+
+An agent to handle apt/dpkg tasks such as finding the total number of upgrades available, listing the total number of packages installed, or executing an 'apt-get clean' or 'apt-get update'.
+
+Installation
+------------
+
+ * The source for the plugin is [GitHub](https://github.com/mstanislav/mCollective-Agents/tree/master/apt)
+
+Usage
+-----
+### Update
+
+<pre>
+# mc-apt update
+Do you really want to operate on services unfiltered? (y/n): y
+server01.example.com                                : OK
+server02.example.com                                : OK
+server03.example.com                                : OK
+server04.example.com                                : OK
+server05.example.com                                : OK
+</pre>
+
+### Clean
+
+<pre>
+# mc-apt clean
+Do you really want to operate on services unfiltered? (y/n): y
+server01.example.com                                : OK
+server02.example.com                                : OK
+server03.example.com                                : OK
+server04.example.com                                : OK
+server05.example.com                                : OK
+</pre>
+
+### Installed
+
+<pre>
+# mc-apt installed
+Do you really want to operate on services unfiltered? (y/n): y
+server01.example.com                                : 755
+server02.example.com                                : 832
+server03.example.com                                : 744
+server04.example.com                                : 755
+server05.example.com                                : 832
+</pre>
+
+</pre>
+
+### Upgrades
+
+<pre>
+# mc-apt upgrades
+Do you really want to operate on services unfiltered? (y/n): y
+server01.example.com                                : 57
+server02.example.com                                : 19
+server03.example.com                                : 0
+server04.example.com                                : 0
+server05.example.com                                : 0
+</pre>

--- a/website/plugin_directory/authorization_action_policy.markdown
+++ b/website/plugin_directory/authorization_action_policy.markdown
@@ -1,0 +1,6 @@
+---
+layout: normal
+title: "MCollective Plugin: Authorization Action Policy"
+---
+
+The documentation for this plugin can be found in its [GitHub repository](https://github.com/puppetlabs/mcollective-actionpolicy-auth#readme).

--- a/website/plugin_directory/central_rpc_log.markdown
+++ b/website/plugin_directory/central_rpc_log.markdown
@@ -1,0 +1,92 @@
+---
+layout: normal
+title: "MCollective Plugin: Central RPC Log"
+---
+
+Centralized RPC Audit Logs
+==========================
+
+This is a [SimpleRPC Audit Plugin](http://docs.puppetlabs.com/mcollective/simplerpc/auditing.html) and Agent that sends all SimpleRPC audit events to a central point for logging.
+
+You'd run the audit plugin on every node and designate one node as the receiver of audit logs.  The receiver will have a detailed log of every SimpleRPC request processed on your entire server estate.
+
+There are 2 receiving agents, one that writes a log file:
+
+<pre>
+01/22/10 12:57:34 dev2.foo.net> b10c1a33ad5e8cfaf5f564afa9957c32: 01/22/10 12:57:34 caller=uid=500@devel.your.com agent=iptables action=block
+01/22/10 12:57:34 dev2.foo.net> b10c1a33ad5e8cfaf5f564afa9957c32: {:ipaddr=>"62.x.x.242"}
+01/22/10 12:57:34 dev1.foo.net> b10c1a33ad5e8cfaf5f564afa9957c32: 01/22/10 12:57:34 caller=uid=500@devel.your.com agent=iptables action=block
+01/22/10 12:57:34 dev2.foo.net> b10c1a33ad5e8cfaf5f564afa9957c32: {:ipaddr=>"62.x.x.242"}
+</pre>
+
+The example log file is from a remote node _devel.your.com_ it is for a message with the ID _b10c1a33ad5e8cfaf5f564afa9957c32_, the caller ran as unix process id _500_.
+
+It sent a request to the _iptables_ agent with the action _block_ and the parameter _ipaddr = 62.x.x.242_.
+
+The other plugin will write to MongoDB:
+
+<pre>
+$ mongo
+MongoDB shell version: 1.4.4
+> use mcollective
+switched to db mcollective
+> db.rpclog.find()
+{ "_id" : ObjectId("4c5975e2dc3ecb0c3b000001"), "agent" : "nrpe", "senderid" : "monitor1.xxx.net", "requestid" : "6c311d786b2d187b231d41f14cbb03ce", "action" : "runcommand", "data" : { "command" : "check_bacula-fd", "process_results" : true }, "caller" : "cert=nagios@monitor1.xxx.net" }
+</pre>
+
+There are some limitations to the design of this plugin, I suspect it will be affective to only a few 100 machines.  This is due to RPC requests being used to create the audit entries.  If the central host isn't fast there might be some overflow and discarding happening.  
+
+I'd be interested in working with someone to improve this, we'd essentially write audit log entries to a Queue and have a daemon that consumes the queue, this will ensure that all logs get saved to the DB.
+
+Installation
+============
+
+Every Node
+----------
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/audit/centralrpclog/audit/).
+
+
+Add to the configuration:
+
+<pre>
+rpcaudit = 1
+rpcauditprovider = centralrpclog
+</pre>
+
+Since version _1.1.3_ of MCollective we support sub collective, you can specify which collective to use:
+
+<pre>
+plugin.centralrpclog.collective = audit
+</pre>
+
+And restart
+
+Central Audit Node
+------------------
+
+### File logging agent
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/audit/centralrpclog/agent/).
+
+
+Add to the configuration:
+
+<pre>
+plugin.centralrpclog.logfile = /var/log/mcollective-rpcaudit.log
+</pre>
+
+ * Set up log rotation for _/var/log/mcollective-rpcaudit.log_ using your Operating Systems log rotation system.
+
+### MongoDB agent
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/audit/centralrpclog/agent/).
+
+
+Add to your configuration, these are the defaults so you can just keep it like this if its ok:
+
+<pre>
+plugin.centralrpclog.mongohost = localhost
+plugin.centralrpclog.mongodb = mcollective
+plugin.centralrpclog.collection = rpclog
+</pre>

--- a/website/plugin_directory/discovery_assisted_ssh.markdown
+++ b/website/plugin_directory/discovery_assisted_ssh.markdown
@@ -1,0 +1,15 @@
+If you're using the discovery filters heavily, you might also want to use SSH based on these filters. We have 2 client scripts that help you do this at [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/utilities/mc-ssh).
+
+The first uses the [Highline](http://highline.rubyforge.org/) gem and looks something like this:
+
+<pre>
+% mc-ssh -W country=za -- -l root
+1. node1.your.com
+2. node2.your.com
+3. Exit
+1
+Running: ssh node1.your.com -l root
+Last login: Sat Dec 18 17:01:35 2010 from nephilim.ml.org
+</pre>
+
+The second uses the [RDialog](http://rdialog.rubyforge.org/) gem to display the menu using a curses UI.

--- a/website/plugin_directory/facter.markdown
+++ b/website/plugin_directory/facter.markdown
@@ -1,0 +1,6 @@
+---
+layout: normal
+title: "MCollective Plugin: Facter "
+---
+
+The documentation for this plugin can be found in its [GitHub repository](https://github.com/puppetlabs/mcollective-facter-facts#readme). 

--- a/website/plugin_directory/facter_via_yaml.markdown
+++ b/website/plugin_directory/facter_via_yaml.markdown
@@ -1,0 +1,95 @@
+---
+layout: normal
+title: "MCollective Plugin: Facter via YAML"
+---
+
+# Overview
+
+
+This method of accessing facts is what we recommend for Puppet users, it's faster and deals better with some strange issues in Facter.
+
+Essentially we use Puppet to dump the data it gathers during normal runs into a YAML file and just use the MCollective YAML fact source to read this data.  This avoids an extreme slowdown from Facter running on every mcollective invocation, plus it lets you get any in-scope variables (for example, parameters from your external node classifier) available as mcollective filters for free. 
+
+# Creating the YAML
+
+In your Puppet manifests create a class similar to below: (Thanks to Dave Ta for this recipe, and to Jesse Throwe for the Ruby 1.9 fix)
+
+<pre>
+class mcollective::facts ()
+{
+  #The facts.yaml file resource is generated in its own dedicated class
+  #By doing this, the file produced isn't polluted with unwanted in scope class variables.
+ 
+  ##Bring in as many variables as you want from other classes here.
+  #This makes them available to mcollective for use in filters.
+  #eg
+  #$class_variable = $class::variable
+ 
+  #mcollective doesn't work with arrays, so use the puppet-stdlib join function
+  #eg
+  #$ntp_servers = join($ntp::servers, ",")
+ 
+  file{'/etc/mcollective/facts.yaml':
+   owner    => root,
+   group    => root,
+   mode     => 400,
+   content => template('mcollective/facts.yaml.erb'),
+  }
+}
+</pre>
+
+
+## facts.yaml.erb
+<pre>
+<%=
+    # remove dynamic facts
+    obj = scope.to_hash.reject {|k,v| k.to_s =~ /^(uptime.*|rubysitedir|_timestamp|memoryfree.*|swapfree.*|title|name|caller_module_name|module_name)$/ }
+
+    arr = obj.sort
+    out = "---\n"
+    arr.each do |element|
+      entry = {element[0] => element[1]}
+      out += entry.to_yaml.split(/\n/)[1..-1].join("\n") + "\n"
+    end
+
+    out
+%>
+</pre>
+
+Apply this to all the nodes that run MCollective.
+
+# Configure MCollective
+
+Add the following lines to <em>server.cfg</em>
+
+<pre>
+factsource = yaml
+plugin.yaml = /etc/mcollective/facts.yaml
+</pre>
+
+# Verify
+
+<pre>
+% mc-inventory some.node
+Inventory for some.node:
+
+   Server Statistics:
+                      Version: 0.4.10
+                   Start Time: Mon Nov 29 16:38:28 +0000 2010
+                  Config File: /etc/mcollective/server.cfg
+                   Process ID: 5387
+               Total Messages: 9254
+      Messages Passed Filters: 6443
+            Messages Filtered: 2811
+                 Replies Sent: 6442
+         Total Processor Time: 23.27 seconds
+                  System Time: 6.19 seconds
+
+<snip>
+
+   Facts:
+      architecture => i386
+      clientcert => some.node
+      clientversion => 2.6.3
+      country => de
+</pre>

--- a/website/plugin_directory/index.markdown
+++ b/website/plugin_directory/index.markdown
@@ -1,0 +1,68 @@
+---
+layout: default
+title: "MCollective Plugin Directory"
+---
+
+This directory of MCollective plugins was migrated from the Puppet Labs wiki in January, 2015. 
+
+# Agents
+
+ * [Apt](apt.html) - Perform various tasks for apt/dpkg
+ * [File Manager](agent_file_manager.html) - create, touch, remove and retrieve information about files
+ * [IP Tables Junkfilter Manager](agent_iptables_junk_filter.html) - Add, removes and queries rules on a specific chain
+ * [Net Test](net_test.html) - Performs network reachability testing
+ * [NRPE](nrpe_agent.html) - Runs NRPE commands using MCollective as transport
+ * [Process](process_management.html) - Manage server processes
+ * [Puppet](puppet_agent.html) - enable, disable, run puppet daemons. 
+ * [Puppet CA](puppet_ca.html) - Manage the Puppet Certificate Authority
+ * [Package](package.html) - installs, uninstalls and query Operating System packages
+ * [Packages](packages.html) - install, update, uninstall multiple packages in one run with fine version/revision control
+ * [Service](services.html) - stop, starts and query Operating System services
+ * [Spam Assassin](spamassassin.html) - Perform various tasks for Spam Assassin
+ * [Stomp Utilities](stomp_util.html) - helpers and utilities for the STOMP connector
+
+# Fact Sources
+
+
+ * [Facter via YAML](facter_via_yaml.html) - Access Facter variables as YAML
+ * [Facter](facter.html) - Use Puppet Labs Facter as a fact source
+ * [Ohai](ohai.html) - Use OpsCode Ohai as a fact source
+
+# Auditing
+
+
+ * [Central RPC Log](central_rpc_log.html) - Logs RPC audit logs to a central log file or MongoDB instance
+ * [Central LogStash log](logstash_rpc_audit_logs.html) - Logs RPC audit logs to a central [LogStash](http://code.google.com/p/logstash/) instance
+
+# Authorization
+
+ * [Action Policy](authorization_action_policy.html) - Authorization plugin with fine grain per action ACLs
+
+# Data
+
+ * [Puppet Resource Status]() - Datasource to facilitate discovery of machines based on the state of Puppet resources
+ * [Sysctl Value](sysctl_data.html) - Datasource to retrieve values from any Linux sysctl
+ * [Agent Meta Data](agent_metadata.html) - Datasource to retrieve meta data about currently installed agents for nodes
+
+# Discovery
+
+
+ * [Registration Data in MongoDB](agent_registration_mongodb.html) - Discover against registration data in a MongoDB NoSQL server
+
+# Security
+
+ 
+ * [None](none.html) - A plugin for development that provides no security
+
+# Registration
+
+
+ * [Meta Data](agent_metadata.html) - Sends agents, facts and classes lists to registration agents
+ * [Registration Monitor](agent_registration_monitor.html) - Writes registration data to file and a Nagios check
+ * [Registration Data in MongoDB](agent_registration_mongodb.html) - Writes registration data to a MongoDB NoSQL server
+
+# Tools
+
+
+ * [Puppet Commander](puppet_commander.html) - schedule puppet runs on a group of hosts with enforced concurrency
+ * [SSH](discovery_assisted_ssh.html) - Discovery assisted ssh

--- a/website/plugin_directory/logstash_rpc_audit_logs.markdown
+++ b/website/plugin_directory/logstash_rpc_audit_logs.markdown
@@ -1,0 +1,7 @@
+---
+layout: normal
+title: "MCollective Plugin: Logstash RPC Audit Logs"
+---
+
+The documentation for this plugin can be found in its [GitHub repository](https://github.com/puppetlabs/mcollective-logstash-audit#readme). 
+

--- a/website/plugin_directory/net_test.markdown
+++ b/website/plugin_directory/net_test.markdown
@@ -1,0 +1,6 @@
+---
+layout: normal
+title: "MCollective Plugin: Net Test Agent"
+---
+
+The documentation for this plugin can be found in its [GitHub Repository](https://github.com/puppetlabs/mcollective-nettest-agent#readme)

--- a/website/plugin_directory/none.markdown
+++ b/website/plugin_directory/none.markdown
@@ -1,0 +1,22 @@
+---
+layout: normal
+title: "MCollective Plugin: No Security"
+---
+
+This plugin is very easy to use as it provides no security there are no certificates or pre shared keys to setup.  The intention is to use it in development and testing but **NOT IN PRODUCTION**
+
+Installation
+============
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/security/none/).
+
+
+Configuration
+=============
+
+Set the following in both server and client config files:
+
+<pre>
+securityprovider = none
+</pre>
+

--- a/website/plugin_directory/nrpe_agent.markdown
+++ b/website/plugin_directory/nrpe_agent.markdown
@@ -1,0 +1,5 @@
+---
+layout: normal
+title: "MCollective Plugin: NRPE Agent"
+---
+The documentation for this plugin can be found in its [GitHub Repository](https://github.com/puppetlabs/mcollective-nrpe-agent#readme)

--- a/website/plugin_directory/ohai.markdown
+++ b/website/plugin_directory/ohai.markdown
@@ -1,0 +1,52 @@
+---
+layout: normal
+title: "MCollective Plugin: Ohai"
+---
+
+
+# Overview
+
+The Ohai plugin enables mcollective to use [OpsCode Ohai](http://wiki.opscode.com/display/chef/Ohai) as a source for facts about your system.
+
+This plugin uses a 3000 second cache for facts, after that it will reset Ohai and regenerate all the facts, this adds a few seconds or so overhead to discovery. 
+
+This plugin is released as Apache License v2 same as the license of Ohai. 
+
+# Installation 
+
+
+If you are using MCollective 1.1.0 or newer you need the file `opscodeohai_facts.rb`. Otherwise, use `opscodeohai.rb`.
+
+ * The source for the plugin is [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/facts/ohai/)
+
+# Configuration
+
+
+You can set the following config options in the <em>server.cfg</em>
+
+ * You have to set _factsource = opscodeohai_ in _server.cfg_ to tell it to load this plugin
+
+If you have MCollective 1.0.x and older:
+
+ * plugin.facter.cache_time - how long to cache for, defaults to 300
+
+If you have Mcollective 1.1.x and newer:
+
+ * fact\_cache\_time - how long to cache for, defaults to 300
+
+
+# Usage
+
+You should now be able to do use all your ohai facts in discovery and fact reporting.
+
+<pre>
+$ mc-facts platform_version
+Report for fact: platform_version                            
+
+        5.3                                     found 3 times
+        5.4                                     found 10 times
+
+Finished processing 13 hosts in 5007.51 ms
+</pre>
+
+You can also use all these facts in your usual discovery lookups etc. 

--- a/website/plugin_directory/package.markdown
+++ b/website/plugin_directory/package.markdown
@@ -1,0 +1,6 @@
+---
+layout: normal
+title: "MCollective Plugin: Package Agent"
+---
+
+The documentation for this plugin can be found in its [GitHub Repository](https://github.com/puppetlabs/mcollective-package-agent#readme)

--- a/website/plugin_directory/packages.markdown
+++ b/website/plugin_directory/packages.markdown
@@ -1,0 +1,63 @@
+---
+layout: normal
+title: "MCollective Plugin: Packages Agent"
+---
+
+Packages agent for MCollective - a agent to install/upgrade/downgrade
+multiple packages at a time.
+
+When using MCollective to roll-out changes in a Continuous Delivery
+environment, the included has some shortcomings, the main one being
+that it does not support multiple packages in one run, which adds
+overhead.
+
+Packages agent tackles the following requirements
+1. The client does not know wether a package is already installed or not.
+1. Allow install, update and downgrade.
+1. Handle multiple packages in one operation.
+1. Respond with a list of packages and their exact version/revision installed.
+1. Re-try operations when they fail.
+1. Include "yum clean expire-cache"
+
+Limitations
+===========
+
+Mainly tested on Scientific Linux 6.1.
+
+Installation
+============
+
+The source is on [GitHub](https://github.com/jbraeuer/mcollective-plugins/tree/packages/agent/packages/)
+
+Usage
+=====
+
+Install multiple packages at a time:
+
+<pre>
+% mco packages uptodate htop iotop
+Do you really want to operate on packages unfiltered? (y/n): y
+
+ * [ ============================================================> ] 5 / 5
+
+ip-10-56-51-48                           = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-56-5-253                           = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-250-141-198                        = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-56-46-219                          = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-250-126-24                         = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+
+</pre>
+
+Request installation of specific version (and disable y/n for automated deployments):
+
+<pre>
+# mco packages --batch uptodate htop/0.8.3/2.el6 iotop/0.3.2/3.el6
+
+ * [ ============================================================> ] 5 / 5
+
+ip-10-56-46-219                          = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-56-5-253                           = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-250-126-24                         = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-56-51-48                           = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+ip-10-250-141-198                        = OK ::: [{"name":"htop","tries":1,"version":"0.8.3","status":0,"release":"2.el6"},{"name":"iotop","tries":1,"version":"0.3.2","status":0,"release":"3.el6"}] :::
+</pre>

--- a/website/plugin_directory/process_management.markdown
+++ b/website/plugin_directory/process_management.markdown
@@ -1,0 +1,102 @@
+---
+layout: normal
+title: "MCollective Plugin: Process Management Agent"
+---
+
+An agent that can be used for process management like the Unix _pgrep_, _kill_ and _pkill_
+
+**WARNING:** You should use the _kill_ and _pkill_ actions with extreme caution, you can do extensive damage to the availability of your infrastructure using these.
+
+Installation
+============
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/process/)
+ * You need to have the [sys-proctable](http://raa.ruby-lang.org/project/sys-proctable/) Gem installed
+
+Usage
+=====
+
+There is a bundled _pgrep_ utility:
+
+<pre>
+% mc-pgrep ruby
+
+ * [ ============================================================> ] 48 / 48
+
+node1.your.com
+32470 root        92.805MB  ruby /usr/sbin/mcollectived --pid=/var/run/mcollectived.pid 
+
+node2.your.com
+ 1997 root        40.539MB  /usr/bin/ruby /usr/sbin/puppetd --onetime
+12316 root        25.676MB  ruby /usr/sbin/mcollectived --pid=/var/run/mcollectived.pid 
+
+&lt;snip&gt;
+
+   ---- process list stats ----
+        Matched hosts: 48
+    Matched processes: 111
+        Resident Size: 771.502MB
+         Virtual Size: 9.318GB
+</pre>
+
+The process agent can return vast amounts of information, here is init on one machine:
+
+<pre>
+    {:pslist=>
+      [{:startcode=>134512640,
+        :kstkeip=>12850178,
+        :root=>"/",
+        :euid=>0,
+        :blocked=>0,
+        :cminflt=>3341998871,
+        :cutime=>6433066,
+        :itrealvalue=>0,
+        :tty_nr=>0,
+        :majflt=>20,
+        :wchan=>0,
+        :utime=>6,
+        :name=>"init",
+        :uid=>0,
+        :egid=>0,
+        :cmajflt=>51118,
+        :signal=>0,
+        :cmdline=>"init [3]",
+        :ppid=>0,
+        :cstime=>3222029,
+        :fd=>{"10"=>"/dev/initctl"},
+        :sigignore=>1475401980,
+        :cwd=>"/",
+        :gid=>0,
+        :vsize=>2224128,
+        :processor=>0,
+        :environ=>{"TERM"=>"linux", "HOME"=>"/"},
+        :pid=>1,
+        :nswap=>0,
+        :rt_priority=>0,
+        :flags=>4194560,
+        :nice=>0,
+        :cnswap=>0,
+        :comm=>"init",
+        :state=>"S",
+        :endcode=>134544728,
+        :username=>"root",
+        :rss=>172,
+        :startstack=>3216723968,
+        :exe=>"/sbin/init",
+        :rlim=>4294967295,
+        :starttime=>63,
+        :policy=>0,
+        :tpgid=>-1,
+        :exit_signal=>0,
+        :pgrp=>1,
+        :minflt=>699,
+        :stime=>29,
+        :priority=>15,
+        :session=>1,
+        :kstkesp=>3216722652,
+        :sigcatch=>671819267}]},
+</pre>
+
+For this reason you need to be careful about large pgrep's over large infrastructures the resulting data that needs to be transfered and processed on your machine can be staggering, each node will return as much as half a MB of serialized data.
+
+The kill and pkill commands are not documented here and is in general not recommended to use.

--- a/website/plugin_directory/puppet_agent.markdown
+++ b/website/plugin_directory/puppet_agent.markdown
@@ -1,0 +1,8 @@
+---
+layout: normal
+title: "MCollective Plugin: AgentPuppet"
+---
+
+This is a rewrite of the older Puppetd agent which supports many new features and Puppet 3.
+
+The documentation for this plugin is on [GitHub](https://github.com/puppetlabs/mcollective-puppet-agent#readme)

--- a/website/plugin_directory/puppet_ca.markdown
+++ b/website/plugin_directory/puppet_ca.markdown
@@ -1,0 +1,98 @@
+---
+layout: normal
+title: "MCollective Plugin: Puppet CA Agent"
+---
+
+This agent lets you sign, list, revoke and clean certificates on your Puppet Certificate Authorities
+
+Installation
+============
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/puppetca/)
+
+
+Usage
+=====
+
+The commands available are shown below:
+
+List:
+-----
+
+<pre>
+% mco rpc puppetca list
+Determining the amount of hosts matching filter for 2 seconds .... 2
+
+ * [ ============================================================> ] 2 / 2
+
+
+puppet1.your.net:
+         Signed:
+           ["host1.your.net",
+            "host2.your.net"]
+         Waiting CSRs:
+           ["host3.your.net"]
+
+puppet2.your.net:
+         Signed:
+           ["host4.your.net",
+            "host5.your.net"]
+         Waiting CSRs:
+           []
+</pre>
+
+Sign:
+-----
+
+<pre>
+% mco rpc puppetca sign certname=host3.your.net
+Determining the amount of hosts matching filter for 2 seconds .... 2
+
+ * [ ============================================================> ] 2 / 2
+
+
+puppet2.your.net                  Request Aborted
+   No cert found to sign
+
+puppet1.your.net
+   Result: notice: Signed certificate request for host3.your.net
+           notice: Removing file Puppet::SSL::CertificateRequest host3.your.net at '/var/lib/puppet/ssl/ca/requests/host3.your.net.pem'
+
+
+Finished processing 2 / 2 hosts in 1207.45 ms
+</pre>
+
+Revoke:
+-------
+
+Note how puppetca doesn't behave too well when you ask it to revoke a certificate that doesn't exist, doesn't cause problems though
+
+<pre>
+% mco rpc puppetca revoke certname=host3.your.net
+Determining the amount of hosts matching filter for 2 seconds .... 2
+
+ * [ ============================================================> ] 2 / 2
+
+
+puppet1.your.net                  
+   Result: notice: Revoked certificate with serial 156
+
+puppet2.your.net
+   Result: notice: Revoked certificate with serial # Inventory of signed certificates
+</pre>
+
+Clean
+-----
+
+<pre>
+% mco rpc puppetca clean certname=host3.your.net
+Determining the amount of hosts matching filter for 2 seconds .... 2
+
+ * [ ============================================================> ] 2 / 2
+
+
+monitor3.your.net                  
+   Result: Removed signed cert: /var/lib/puppet/ssl/ca/signed/host3.your.net.pem.
+
+
+Finished processing 2 / 2 hosts in 355.97 ms

--- a/website/plugin_directory/puppet_commander.markdown
+++ b/website/plugin_directory/puppet_commander.markdown
@@ -1,0 +1,50 @@
+---
+layout: normal
+title: "MCollective Plugin: Puppet Commander"
+---
+
+The Puppet Commander solves the problem where at times even when using splay you will find a large amount of checkins hitting your master and overwhelming it.
+
+The basic theory is that using the [Puppet Agent plugin](puppet_agent.html) we can figure out how many machines are currently running and we can schedule runs.  We can thus ensure that at any given time we only schedule a certain amount of current runs.  This will help you with capacity planning of your masters.
+
+As a side effect it also means if you are busy managing servers and running _puppetd --test_ runs or some other scheduled runs the commander will back down and not schedule runs, leaving the resources of the master free for your interactive use.
+
+Installation
+------------
+
+ * You need to have [Puppet Agent](puppet_agent.html) installed and working.
+ * You should not be running the Puppet Daemons, shut those services down.
+ * Get the code from [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/puppetd/commander/).
+ * Place the _puppetcommanderd_ script in _/usr/sbin_.
+ * Place the _puppetcommander.init_ in your rc directory, often that is _/etc/init.d/puppetcommander_ and enable it.
+ * Create _/etc/sysconfig/puppetcommanderd_ and set any settings like those for security plugins or MCOLLECTIVE_EXTRA_OPTS.
+ * Create _/etc/puppetcommander.cfg_ from the provided template.
+
+Configuration
+-------------
+
+A sample config file can be seen below:
+
+<pre>
+---
+:filter: "country=/de|uk|za/"
+:interval: 30
+:concurrency: 2
+:randomize: true
+:logfile: /var/log/puppetcommander.log
+:daemonize: true
+</pre>
+
+It runs my nodes in _de_, _uk_ and _za_ in 30 minutes, never more than 2 at a time.  It will shuffle the nodes it discovered and log to the given log file.
+
+The filter option above is quite limiting, from MCollective 1.1.0 and newer to supply filters do the following in _/etc/sysconfig/puppetcommanderd_, this lets you supply a much richer set of filters than before.
+
+<pre>
+export MCOLLECTIVE_EXTRA_OPTS="-W country=/de|uk|za/"
+</pre>
+
+And set the filter in the YAML above to:
+
+<pre>
+:filter: ""
+</pre>

--- a/website/plugin_directory/registration_metadata.markdown
+++ b/website/plugin_directory/registration_metadata.markdown
@@ -1,0 +1,30 @@
+---
+layout: normal
+title: "MCollective Plugin: Registration Metadata"
+---
+
+Sends all available metadata via the registration mechanism, at present this is:
+
+ * All facts
+ * All agents
+ * List of all classes
+
+Installation
+============
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/registration/).
+
+
+Configuration
+=============
+
+For full details about the registration system see [Registration](http://docs.puppetlabs.com/mcollective/reference/plugins/registration.html)
+
+The simplest configuration for this plugin is:
+
+<pre>
+registerinterval = 300
+registration = Meta
+</pre>
+
+You should also set up a receiver, such as [agent registration monitor](agent_registration_monitor.html) or [agent registration for MongoDB](agent_registration_mongodb.html).

--- a/website/plugin_directory/resources_data_plugin.markdown
+++ b/website/plugin_directory/resources_data_plugin.markdown
@@ -1,0 +1,6 @@
+---
+layout: normal
+title: "MCollective Plugin: Resources Data"
+---
+
+This plugin has been incorporated into the new Puppet agent, which can be found on [GitHub](https://github.com/puppetlabs/mcollective-puppet-agent#readme).

--- a/website/plugin_directory/services.markdown
+++ b/website/plugin_directory/services.markdown
@@ -1,0 +1,6 @@
+---
+layout: normal
+title: "MCollective Plugin: Services Agent"
+---
+
+The documentation for this plugin can be found in its [GitHub Repository](https://github.com/puppetlabs/mcollective-service-agent#readme)

--- a/website/plugin_directory/spamassassin.markdown
+++ b/website/plugin_directory/spamassassin.markdown
@@ -1,0 +1,105 @@
+---
+layout: normal
+title: "MCollective Plugin: SpamAssassin"
+---
+
+
+Introduction
+------------
+
+An agent to handle Spam Assassin tasks such as compiling a ruleset, restarting the service, viewing the service status + compiled ruleset modified timestamp, checking for ruleset syntax errors, and executing an sa-update. Alternatively, the 'full' command will execute an update, compilation, and restart all at once.
+
+Installation
+------------
+
+The source for the plugin is [GitHub](https://github.com/mstanislav/mCollective-Agents/tree/master/spamassassin)
+
+
+Configuration
+-------------
+
+Below are the currently available plugin configuration options:
+
+<pre>
+plugin.spamassassin.compiled_ruleset = /var/lib/spamassassin/compiled/5.008/3.002005/Mail/SpamAssassin/CompiledRegexps/body_0.pm
+</pre>
+
+Usage
+-----
+### Status
+
+<pre>
+# mc-spamassassin -W "purpose=asav" status
+asav01.example.com                      RUNNING, COMPILED RULESET MON JAN 17 15:14:03 -0600 2011
+asav02.example.com                      RUNNING, COMPILED RULESET MON JAN 17 15:18:28 -0600 2011
+asav03.example.com                	    RUNNING, COMPILED RULESET MON JAN 17 15:20:53 -0600 2011
+asav04.example.com                	    RUNNING, COMPILED RULESET MON JAN 17 15:27:06 -0600 2011
+asav05.example.com                	    RUNNING, COMPILED RULESET MON JAN 17 15:24:07 -0600 2011
+
+Finished processing 5 / 5 hosts in 380.58 ms
+</pre>
+
+### Update
+
+<pre>
+# mc-spamassassin -W "purpose=asav" update
+asav02.example.com                       NO UPDATES FOUND
+asav03.example.com                       NO UPDATES FOUND
+asav05.example.com                	     NO UPDATES FOUND
+asav04.example.com                	     NO UPDATES FOUND
+asav01.example.com                       NO UPDATES FOUND
+
+Finished processing 5 / 5 hosts in 956.66 ms
+</pre>
+
+### Compile
+
+<pre>
+# mc-spamassassin -W "purpose=asav" compile
+asav05.example.com                	     OK
+asav03.example.com                       OK
+asav02.example.com                       OK
+asav04.example.com                	     OK
+asav01.example.com                       OK
+
+Finished processing 5 / 5 hosts in 61450.94 ms
+</pre>
+
+### Lint
+
+<pre>
+# mc-spamassassin -W "purpose=asav" lint
+asav05.example.com                	     3 SYNTAX ERRORS
+asav02.example.com                       SYNTAX OK
+asav04.example.com                	     2 SYNTAX ERRORS
+asav03.example.com                       SYNTAX OK
+asav01.example.com                       SYNTAX OK
+
+Finished processing 5 / 5 hosts in 5004.15 ms
+</pre>
+
+### Restart
+
+<pre>
+# mc-spamassassin -W "purpose=asav" restart
+asav05.example.com                	     OK
+asav04.example.com                	     OK
+asav02.example.com                       OK
+asav03.example.com                       OK
+asav01.example.com                       OK
+
+Finished processing 5 / 5 hosts in 5134.55 ms
+</pre>
+
+### Full
+
+<pre>
+# mc-spamassassin -W "purpose=asav" full
+asav05.example.com                	     NO UPDATES FOUND, COMPILATION OK, RESTART OK
+asav02.example.com                       NO UPDATES FOUND, COMPILATION OK, RESTART OK
+asav04.example.com                	     NO UPDATES FOUND, COMPILATION OK, RESTART OK
+asav03.example.com                       NO UPDATES FOUND, COMPILATION OK, RESTART OK
+asav01.example.com                       NO UPDATES FOUND, COMPILATION OK, RESTART OK
+
+Finished processing 5 / 5 hosts in 66339.50 ms
+</pre>

--- a/website/plugin_directory/stomp_util.markdown
+++ b/website/plugin_directory/stomp_util.markdown
@@ -1,0 +1,80 @@
+---
+layout: normal
+title: "MCollective Plugin: STOMP Utilities"
+---
+
+*NOTE:* This plugin will be removed when MCollective 2.2.x comes to an end due to the deprecation of the STOMP connector.
+
+Helpers and utilities for the MCollective STOMP connector
+
+Installation
+============
+
+The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/stomputil/)
+
+Usage
+=====
+
+Connection Information:
+-----------------------
+The idea is that if you have a network with failover STOMP servers you might need some visibility about what is connected where, this agent and bundled utility will help you with that.
+
+<pre>
+% mco rpc stomputil peer_info
+Determining the amount of hosts matching filter for 2 seconds .... 1
+
+ * [ ============================================================> ] 1 / 1
+
+
+node1.your.net                          
+       Host: stomp1.your.net
+    Address: 192.168.1.10
+   Protocol: AF_INET
+       Port: 6163
+
+Finished processing 1 / 1 hosts in 71.25 ms
+</pre>
+
+You can also view all the nodes using the peer map utility.
+
+<pre>
+$ mc-peermap country
+stomp1.your.net -+ 22 nodes with 16.08ms average ping [de] 
+                 |-node1.your.net
+                 &lt;snip&gt;
+
+stomp3.your.net -+ 19 nodes with 123.07ms average ping [uk] 
+                 |-node10.your.net
+                 &lt;snip&gt;
+
+
+stomp2.your.net -+ 7 nodes with 363.30ms average ping [us] 
+                 |-node20.your.net
+                 &lt;snip&gt;
+
+</pre>
+
+Notice that I specified _country_ on the command line this causes the fact country for each STOMP server to be displayed in the output.
+
+Reconnect:
+----------
+
+If you determined with the command above that you have nodes you'd rather reconnect to their primary STOMP server use this to disconnect and reconnect to the middleware, recreating all subscriptions and reloading all agents.
+
+**NOTE:** You do not want to run this against all your machines at once, take them in batches.
+
+<pre>
+% mco rpc -I your.node.com stomputil reconnect
+Determining the amount of hosts matching filter for 2 seconds .... 1
+
+ * [ ============================================================> ] 1 / 1
+
+
+nod1.your.net                          
+   Restarted: 1
+
+
+Finished processing 1 / 1 hosts in 591.50 ms
+</pre>
+
+

--- a/website/plugin_directory/sysctl_data.markdown
+++ b/website/plugin_directory/sysctl_data.markdown
@@ -1,0 +1,17 @@
+Introduction
+------------
+
+This plugin can retrive a value from a Linux sysctl variable to be used in agents and discovery.
+
+Sample usage to select all machines where ipv4 forwarding is enabled:
+
+<pre>
+$ mco find -S "sysctl('net.ipv4.conf.all.forwarding').value=1"
+</pre>
+
+
+Installation
+=======
+
+ * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/data/sysctl/).
+


### PR DESCRIPTION
This commit provides a new directory for the plugins previously hosted on the Redmine wiki.

There may be some issues with formatting, but we need to move ahead with the migration to expedite the wiki content migration. 