### PR TITLE
Fix: Replaces erroneous template name with correct one.

### DIFF
--- a/website/plugin_directory/agent_file_manager.markdown
+++ b/website/plugin_directory/agent_file_manager.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: File Manager Agent"
 ---
 

--- a/website/plugin_directory/agent_iptables_junk_filter.markdown
+++ b/website/plugin_directory/agent_iptables_junk_filter.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: IP Tables Junkfilter Agent"
 ---
 

--- a/website/plugin_directory/agent_metadata.markdown
+++ b/website/plugin_directory/agent_metadata.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Agent Metadata"
 ---
 

--- a/website/plugin_directory/agent_registration_mongodb.markdown
+++ b/website/plugin_directory/agent_registration_mongodb.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: MongoDB Registration Agent"
 ---
 

--- a/website/plugin_directory/agent_registration_monitor.markdown
+++ b/website/plugin_directory/agent_registration_monitor.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Agent Registration Monitor"
 ---
 

--- a/website/plugin_directory/apt.markdown
+++ b/website/plugin_directory/apt.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: AgentApt"
 ---
 

--- a/website/plugin_directory/authorization_action_policy.markdown
+++ b/website/plugin_directory/authorization_action_policy.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Authorization Action Policy"
 ---
 

--- a/website/plugin_directory/central_rpc_log.markdown
+++ b/website/plugin_directory/central_rpc_log.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Central RPC Log"
 ---
 

--- a/website/plugin_directory/facter.markdown
+++ b/website/plugin_directory/facter.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Facter "
 ---
 

--- a/website/plugin_directory/facter_via_yaml.markdown
+++ b/website/plugin_directory/facter_via_yaml.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Facter via YAML"
 ---
 

--- a/website/plugin_directory/logstash_rpc_audit_logs.markdown
+++ b/website/plugin_directory/logstash_rpc_audit_logs.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Logstash RPC Audit Logs"
 ---
 

--- a/website/plugin_directory/net_test.markdown
+++ b/website/plugin_directory/net_test.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Net Test Agent"
 ---
 

--- a/website/plugin_directory/none.markdown
+++ b/website/plugin_directory/none.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: No Security"
 ---
 

--- a/website/plugin_directory/nrpe_agent.markdown
+++ b/website/plugin_directory/nrpe_agent.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: NRPE Agent"
 ---
 The documentation for this plugin can be found in its [GitHub Repository](https://github.com/puppetlabs/mcollective-nrpe-agent#readme)

--- a/website/plugin_directory/ohai.markdown
+++ b/website/plugin_directory/ohai.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Ohai"
 ---
 

--- a/website/plugin_directory/package.markdown
+++ b/website/plugin_directory/package.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Package Agent"
 ---
 

--- a/website/plugin_directory/packages.markdown
+++ b/website/plugin_directory/packages.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Packages Agent"
 ---
 

--- a/website/plugin_directory/process_management.markdown
+++ b/website/plugin_directory/process_management.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Process Management Agent"
 ---
 

--- a/website/plugin_directory/puppet_agent.markdown
+++ b/website/plugin_directory/puppet_agent.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: AgentPuppet"
 ---
 

--- a/website/plugin_directory/puppet_ca.markdown
+++ b/website/plugin_directory/puppet_ca.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Puppet CA Agent"
 ---
 

--- a/website/plugin_directory/puppet_commander.markdown
+++ b/website/plugin_directory/puppet_commander.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Puppet Commander"
 ---
 

--- a/website/plugin_directory/registration_metadata.markdown
+++ b/website/plugin_directory/registration_metadata.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Registration Metadata"
 ---
 

--- a/website/plugin_directory/resources_data_plugin.markdown
+++ b/website/plugin_directory/resources_data_plugin.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Resources Data"
 ---
 

--- a/website/plugin_directory/services.markdown
+++ b/website/plugin_directory/services.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: Services Agent"
 ---
 

--- a/website/plugin_directory/spamassassin.markdown
+++ b/website/plugin_directory/spamassassin.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: SpamAssassin"
 ---
 

--- a/website/plugin_directory/stomp_util.markdown
+++ b/website/plugin_directory/stomp_util.markdown
@@ -1,5 +1,5 @@
 ---
-layout: normal
+layout: default
 title: "MCollective Plugin: STOMP Utilities"
 ---
 


### PR DESCRIPTION
It should be `template: default`, not `template: normal`. The pages still render, this just makes sure they have a template.  