### PR TITLE
Allow mco inventory to work with servers <2.1.0 that don't return any data plugins

### DIFF
--- a/plugins/mcollective/application/inventory.rb
+++ b/plugins/mcollective/application/inventory.rb
@@ -151,7 +151,7 @@ class MCollective::Application::Inventory<MCollective::Application
           puts
 
           puts "   Data Plugins:"
-          if data[:data_plugins].size > 0
+          if data[:data_plugins] != nil and data[:data_plugins].size > 0
             data[:data_plugins].sort.in_groups_of(3, "") do |plugins|
               puts "      %-15s %-15s %-15s" % plugins.map{|p| p.gsub("_data", "")}
             end


### PR DESCRIPTION
Otherwise we get:
   Data Plugins:
Failed to display node inventory: NoMethodError: undefined method `size' for nil:NilClass

