### PR TITLE
MCO-315 make $libdir prepend values to $LOAD_PATH

### DIFF
--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -33,6 +33,18 @@ module MCollective
         expect { Config.instance.loadconfig("/nonexisting") }.to raise_error(/should be absolute paths/)
       end
 
+      it 'should prepend $libdir to $LOAD_PATH' do
+        Util.expects(:absolute_path?).with('/test').returns(true)
+
+        File.stubs(:exists?).with("/nonexisting").returns(true)
+
+        File.expects(:readlines).with('/nonexisting').returns(['libdir = /test'])
+
+        Config.instance.loadconfig("/nonexisting")
+
+        $LOAD_PATH[0].should == '/test'
+      end
+
       it "should not allow any path like construct for identities" do
         # Taken from puppet test cases
         ['../foo', '..\\foo', './../foo', '.\\..\\foo',


### PR DESCRIPTION
Currently the semantics for $libdir are that it's an array of paths
that MCollective should search for plugins.  The change we make
here is to make $libdir more generally extend $LOAD_PATH and use
$LOAD_PATH for all plugin loading.

This allows plugins for to be located in gems and for plugin
resolution to be influenced by the RUBYLIB environent variable, or
the ruby -I switch.

In the configuration parser we make the values supplied by the user
be prepended to the ruby $LOAD_PATH.

When loading plugins we now search all of $LOAD_PATH (via
Config.instance.libdir) for ddl searches and plugin loading.