### PR TITLE
MCO-560 prefer configuration files from AIO paths

### DIFF
--- a/bin/mcollectived
+++ b/bin/mcollectived
@@ -20,7 +20,18 @@ daemonize = nil
 if MCollective::Util.windows?
   configfile = File.join(MCollective::Util.windows_prefix, "etc", "server.cfg")
 else
-  configfile = "/etc/mcollective/server.cfg"
+  # search for the server.cfg in the AIO path then the traditional one
+  configfiles = ['/etc/puppetlabs/agent/mcollective/server.cfg',
+                 '/etc/mcollective/server.cfg' ]
+
+  found = configfiles.find_index { |file| File.readable?(file) }
+
+  # didn't find any? default to the first
+  if found.nil?
+    found = 0
+  end
+
+  configfile = configfiles[found]
 end
 pid = ""
 

--- a/lib/mcollective/rpc.rb
+++ b/lib/mcollective/rpc.rb
@@ -58,7 +58,7 @@ module MCollective
     # exit if there is a failure constructing the RPC client. Set this flag
     # to false to cause an Exception to be raised instead.
     def rpcclient(agent, flags = {})
-      configfile = flags[:configfile] || "/etc/mcollective/client.cfg"
+      configfile = flags[:configfile] || Util.config_file_for_user
       options = flags[:options] || nil
 
       if flags.key?(:exit_on_failure)

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -193,6 +193,28 @@ module MCollective
       end
     end
 
+    describe '#config_file_for_user' do
+      before :each do
+        File.stubs(:expand_path).raises
+        File.stubs(:readable?).returns(false)
+        Util.stubs(:windows?).returns(false)
+      end
+
+      it 'should default to /etc/puppetlabs/agent/mcollective/client.cfg if ~/.mcollective can not be expanded' do
+        Util.config_file_for_user.should == '/etc/puppetlabs/agent/mcollective/client.cfg'
+      end
+
+      it 'should default to ~/.mcollective if it can be expanded' do
+        File.expects(:expand_path).with('~/.mcollective').returns('/home/mco/.mcollective')
+        Util.config_file_for_user.should == '/home/mco/.mcollective'
+      end
+
+      it 'should choose /etc/mcollective/client.cfg if it is readable' do
+        File.expects(:readable?).with('/etc/mcollective/client.cfg').returns(true)
+        Util.config_file_for_user.should == '/etc/mcollective/client.cfg'
+      end
+    end
+
     describe "#default_options" do
       it "should supply correct default options" do
         Config.instance.stubs(:default_discovery_options).returns([])


### PR DESCRIPTION
Here we add a search for readable configuration files, preferring the AIO paths
over the 'classic' /etc/mcollective/{client,server}.cfg paths.

In doing this we refactor config_file_for_user for clarity and add spec tests.