### PR TITLE
MCO-555 Add AIO variants of init and sysconfig files

### DIFF
--- a/ext/aio/README.md
+++ b/ext/aio/README.md
@@ -1,0 +1,5 @@
+All-In-One Agent Support files
+
+Here you'll find the init scripts and supplemental files used by the
+Puppetlabs All-In-One Agent packages built with
+https://github.com/puppetlabs/puppet-agent

--- a/ext/aio/common/client.cfg.dist
+++ b/ext/aio/common/client.cfg.dist
@@ -1,0 +1,16 @@
+main_collective = mcollective
+collectives = mcollective
+libdir = /opt/puppetlabs/agent/plugins
+logger_type = console
+loglevel = warn
+
+# Plugins
+securityprovider = psk
+plugin.psk = unset
+
+connector = activemq
+plugin.activemq.pool.size = 1
+plugin.activemq.pool.1.host = stomp1
+plugin.activemq.pool.1.port = 6163
+plugin.activemq.pool.1.user = mcollective
+plugin.activemq.pool.1.password = marionette

--- a/ext/aio/common/server.cfg.dist
+++ b/ext/aio/common/server.cfg.dist
@@ -1,0 +1,21 @@
+main_collective = mcollective
+collectives = mcollective
+libdir = /opt/puppetlabs/agent/plugins
+logfile = /var/log/puppetlabs/agent/mcollective.log
+loglevel = info
+daemonize = 1
+
+# Plugins
+securityprovider = psk
+plugin.psk = unset
+
+connector = activemq
+plugin.activemq.pool.size = 1
+plugin.activemq.pool.1.host = stomp1
+plugin.activemq.pool.1.port = 6163
+plugin.activemq.pool.1.user = mcollective
+plugin.activemq.pool.1.password = marionette
+
+# Facts
+factsource = yaml
+plugin.yaml = /etc/puppetlabs/agent/mcollective/facts.yaml

--- a/ext/aio/debian/mcollective.default
+++ b/ext/aio/debian/mcollective.default
@@ -1,0 +1,2 @@
+START=true
+DAEMON_OPTS="--pid ${PIDFILE}"

--- a/ext/aio/debian/mcollective.init
+++ b/ext/aio/debian/mcollective.init
@@ -1,0 +1,92 @@
+#!/bin/sh
+#
+# mcollective   Application Server for STOMP based agents
+#
+#
+# description:  mcollective lets you build powerful Stomp compatible middleware clients in ruby without having to worry too
+#               much about all the setup and management of a Stomp connection, it also provides stats, logging and so forth
+#               as a bonus.
+#
+### BEGIN INIT INFO
+# Provides:          mcollective
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start daemon at boot time
+# Description:       Enable service provided by mcollective.
+### END INIT INFO
+
+# check permissions
+
+uid=`id -u`
+[ $uid -gt 0 ] && { echo "You need to be root to run file" ; exit 4 ; }
+
+
+# PID directory
+pidfile="/var/run/puppetlabs/agent/mcollectived.pid"
+
+name="mcollective"
+mcollectived=/opt/puppetlabs/agent/bin/mcollectived
+daemonopts="--pid=${pidfile} --config=/etc/puppetlabs/agent/mcollective/server.cfg"
+
+
+# Source function library.
+. /lib/lsb/init-functions
+
+if [ -f /etc/default/mcollective ]; then
+    . /etc/default/mcollective
+fi
+
+# Check that binary exists
+if ! [ -f $mcollectived ]
+then
+    echo "mcollectived binary not found"
+    exit 5
+fi
+
+# create pid file if it does not exist
+[ ! -f ${pidfile} ] && { touch ${pidfile} ; }
+
+# See how we were called.
+case "$1" in
+    start)
+        echo "Starting daemon: " $name
+        # start the program
+        start-stop-daemon -S -p ${pidfile} --oknodo -q -a ${mcollectived} -- ${daemonopts} --daemonize
+        [ $? = 0 ] && { exit 0 ; } || { exit 1 ; }
+        log_success_msg "mcollective started"
+        touch $lock
+        ;;
+    stop)
+        echo "Stopping daemon: " $name
+        start-stop-daemon -K -R 5 -s "TERM" --oknodo -q -p ${pidfile}
+        [ $? = 0 ] && { exit 0 ; } || { exit 1 ; }
+        log_success_msg "mcollective stopped"
+        ;;
+    restart)
+        echo "Restarting daemon: " $name
+        $0 stop
+        sleep 2
+        $0 start
+        [ $? = 0 ] && { echo "mcollective restarted" ; exit 0 ; }
+        ;;
+    condrestart)
+        if [ -f $lock ]; then
+            $0 stop
+            # avoid race
+            sleep 2
+            $0 start
+        fi
+        ;;
+    force-reload)
+        echo "not implemented"
+        ;;
+    status)
+        status_of_proc -p ${pidfile} ${mcollectived} ${name} && exit 0 || exit $?
+        ;;
+    *)
+        echo "Usage: mcollectived {start|stop|restart|condrestart|status}"
+        exit 2
+        ;;
+esac

--- a/ext/aio/redhat/mcollective-systemd.logrotate
+++ b/ext/aio/redhat/mcollective-systemd.logrotate
@@ -1,0 +1,8 @@
+/var/log/puppetlabs/agent/mcollective.log {
+    missingok
+    notifempty
+    sharedscripts
+    postrotate
+      /usr/bin/systemctl restart mcollective >/dev/null 2>&1 || true
+    endscript
+}

--- a/ext/aio/redhat/mcollective-sysv.logrotate
+++ b/ext/aio/redhat/mcollective-sysv.logrotate
@@ -1,0 +1,8 @@
+/var/log/puppetlabs/agent/mcollective.log {
+    missingok
+    notifempty
+    sharedscripts
+    postrotate
+        /etc/init.d/mcollective restart >/dev/null 2>&1 || true
+    endscript
+}

--- a/ext/aio/redhat/mcollective.init
+++ b/ext/aio/redhat/mcollective.init
@@ -1,0 +1,139 @@
+#!/bin/sh
+#
+# mcollective   Application Server for STOMP based agents
+#
+# chkconfig:    - 24 76
+#
+# description:  mcollective lets you build powerful Stomp compatible middleware clients in ruby without having to worry too
+#               much about all the setup and management of a Stomp connection, it also provides stats, logging and so forth
+#               as a bonus.
+#
+### BEGIN INIT INFO
+# Provides:          mcollective
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
+# Short-Description: Start daemon at boot time
+# Description:       Enable service provided by daemon.
+### END INIT INFO
+
+mcollectived="/opt/puppetlabs/agent/bin/mcollectived"
+pidfile="/var/run/puppetlabs/agent/mcollectived.pid"
+if [ -d /var/lock/subsys ]; then
+    # RedHat/CentOS/etc who use subsys
+    lockfile="/var/lock/subsys/mcollective"
+else
+    # The rest of them
+    lockfile="/var/lock/mcollective"
+fi
+
+# Check that binary exists
+if ! [ -f $mcollectived ]; then
+    echo "mcollectived binary not found"
+    exit 5
+fi
+
+# Source function library.
+. /etc/init.d/functions
+
+if [ -f /etc/sysconfig/mcollective ]; then
+    . /etc/sysconfig/mcollective
+fi
+
+# Determine if we can use the -p option to daemon, killproc, and status.
+# RHEL < 5 can't.
+if status | grep -q -- '-p' 2>/dev/null; then
+    daemonopts="--pidfile $pidfile"
+    pidopts="-p $pidfile"
+fi
+
+start() {
+    echo -n "Starting mcollective: "
+    # Only try to start if not already started
+    if ! rh_status_q; then
+      daemon ${daemonopts} ${mcollectived} --pid=${pidfile} --config="/etc/puppetlabs/agent/mcollective/server.cfg" --daemonize
+    fi
+    # This will be 0 if mcollective is already running
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && touch ${lockfile}
+    return $RETVAL
+}
+
+stop() {
+    echo -n "Shutting down mcollective: "
+    # If running, try to stop it
+    if rh_status_q; then
+      killproc ${pidopts} -d 10 ${mcollectived}
+    else
+      # Non-zero status either means lockfile and pidfile need cleanup (1 and 2)
+      # or the process is already stopped (3), so we can just call true to
+      # trigger the cleanup that happens below.
+      true
+    fi
+    RETVAL=$?
+    echo
+    [ $RETVAL = 0 ] && rm -f ${lockfile} ${pidfile}
+    return $RETVAL
+}
+
+restart() {
+    stop
+    start
+}
+
+reload_agents() {
+    echo -n "Reloading mcollective agents: "
+    killproc ${pidopts} ${mcollectived} -USR1
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
+
+reload_loglevel() {
+    echo -n "Cycling mcollective logging level: "
+    killproc ${pidopts} ${mcollectived} -USR2
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
+
+rh_status() {
+    status ${pidopts} ${mcollectived}
+    RETVAL=$?
+    return $RETVAL
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+# See how we were called.
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    condrestart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    reload-agents)
+        reload_agents
+        ;;
+    reload-loglevel)
+        reload_loglevel
+        ;;
+    status)
+        rh_status
+        ;;
+    *)
+        echo "Usage: mcollectived {start|stop|restart|condrestart|reload-agents|reload-loglevel|status}"
+        RETVAL=2
+        ;;
+esac
+exit $RETVAL

--- a/ext/aio/redhat/mcollective.service
+++ b/ext/aio/redhat/mcollective.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=The Marionette Collective
+After=network.target
+
+[Service]
+Type=forking
+StandardOutput=syslog
+StandardError=syslog
+ExecStart=/opt/puppetlabs/agent/bin/mcollectived --config=/etc/puppetlabs/agent/mcollective/server.cfg --pidfile=/var/run/puppetlabs/agent/mcollective.pid --daemonize
+ExecReload=/bin/kill -USR1 $MAINPID
+PIDFile=/var/run/puppetlabs/agent/mcollective.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/ext/aio/redhat/mcollective.sysconfig
+++ b/ext/aio/redhat/mcollective.sysconfig
@@ -1,0 +1,10 @@
+# Configuration file for mcollectived
+
+# Full path to the mcollectived binary
+#DAEMON=/opt/puppetlabs/agent/bin/mcollectived
+
+# Location of PID file
+#PIDFILE=/var/run/puppetlabs/agent/mcollectived.pid
+
+# Any other parameters to pass to mcollectived
+#DAEMON_OPTS=


### PR DESCRIPTION
The All-In-One Agent configures MCollective with a specific set of
paths for configurations and pidfiles.

Here we take the work of Geoff Nichols from PR#274 and moves it
into ext/aio, where the All-In-One build process can consume the
files.