### PR TITLE
MCO-568 2.8.0 release notes and documentation changes

### DIFF
--- a/website/changelog.md
+++ b/website/changelog.md
@@ -4,7 +4,23 @@ title: Changelog
 toc: false
 ---
 
+## Version 2.8.x
+
+|Date|Description|Ticket|
+|----|-----------|------|
+|2015/02/04|Release *2.8.0*|MCO-561|
+|2015/02/02|Add AIO init scripts to ext/aio|MCO-555|
+|2015/02/02|Move core plugins into sitelibdir|MCO-583|
+|2015/01/29|Prefer configuration files from AIO paths|MCO-560|
+|2015/01/29|Use $LOAD_PATH for loading plugins|MCO-315|
+|2015/01/28|Replace uses of `autoload` with `require`|MCO-580|
+|2015/01/21|Fix `mco facts` in absence of fact|MCO-558|
+|2015/01/07|Ensure rubocop failures fail the build|MCO-519|
+|2014/12/19|Fix powershell exit code interactions|MCO-550|
+
+
 ## Version 2.7.x
+
 |Date|Description|Ticket|
 |----|-----------|------|
 |2014/12/02|Release *2.7.0*|MCO-525|

--- a/website/configure/client.md
+++ b/website/configure/client.md
@@ -129,7 +129,8 @@ The `mco` client is usually run interactively from an admin workstation, but can
 These cases have different needs. In the first, the configuration and credentials should be per-user; in the second, they should be at the system level with restricted visibility of the credentials. MCollective solves this by having two locations for the client configuration:
 
 * `~/.mcollective` --- A `.mcollective` file in the current user's home directory. If this file exists, `mco` will use it instead of the global config file.
-* `/etc/mcollective/client.cfg` --- A global client config file, which will be used if `~/.mcollective` doesn't exist. If you are using this file, read access to it and the external credentials it refers to should be strictly controlled, probably limited to the root user.
+* `/etc/puppetlabs/agent/mcollective/client.cfg` --- A global client config file, which will be used (by versions >= 2.8.0) if `~/.mcollective` doesn't exist. If you are using this file, read access to it and the external credentials it refers to should be strictly controlled, probably limited to the root user.
+* `/etc/mcollective/client.cfg` --- A global client config file, which will be used if `~/.mcollective` and `/etc/puppetlabs/agent/mcollective/client.cfg` don't exist. If you are using this file, read access to it and the external credentials it refers to should be strictly controlled, probably limited to the root user.
 
 ### File Format
 

--- a/website/configure/client.md
+++ b/website/configure/client.md
@@ -580,9 +580,9 @@ The syslog facility to use.
 
 Where to look for plugins. Should be a single path or a list of paths separated by the {{ path_separator }}.
 
-By default, this setting is blank, but the package you installed MCollective with should supply a default server.cfg file with a platform-appropriate value for this setting. **If server.cfg has no value for this setting, MCollective will not work.**
+This setting is optional from 2.8.0 onwards.
 
-- _Default:_ (nothing; the package's default config file usually sets a platform-appropriate value)
+- _Default:_ None
 - _Sample value:_ `/usr/libexec/mcollective:/opt/mcollective`
 
 

--- a/website/configure/server.md
+++ b/website/configure/server.md
@@ -786,9 +786,9 @@ amount of time has elapsed.
 
 Where to look for plugins. Should be a single path or a list of paths separated by the {{ path_separator }}.
 
-By default, this setting is blank, but the package you installed MCollective with should supply a default server.cfg file with a platform-appropriate value for this setting. **If server.cfg has no value for this setting, MCollective will not work.**
+This setting is optional from 2.8.0 onwards.
 
-- _Default:_ (nothing; the package's default config file usually sets a platform-appropriate value)
+- _Default:_ None
 - _Sample value:_ `/usr/libexec/mcollective:/opt/mcollective`
 
 #### `ssl_cipher`

--- a/website/configure/server.md
+++ b/website/configure/server.md
@@ -157,7 +157,7 @@ The Server Config File(s)
 
 ### Main Config File
 
-MCollective servers are configured with the `/etc/mcollective/server.cfg` file. It contains MCollective's core settings, as well as settings for the various plugins.
+MCollective servers are configured with the `server.cfg` file located at `/etc/puppetlabs/agent/mcollective/server.cfg` or `/etc/mcollective/server.cfg`. It contains MCollective's core settings, as well as settings for the various plugins.
 
 > **Warning:** This file contains sensitive credentials, and should only be readable by the root user, or whatever user the MCollective daemon runs as.
 
@@ -176,7 +176,7 @@ The spaces on either side of the equals sign are optional. Lines starting with a
 
 ### Plugin Config Directory (Optional)
 
-Many of MCollective's settings are named with the format `plugin.<NAME>.<SETTING_NAME>`. These settings can optionally be put in separate files, in the `/etc/mcollective/plugin.d/` directory.
+Many of MCollective's settings are named with the format `plugin.<NAME>.<SETTING_NAME>`. These settings can optionally be put in separate files, in the `/etc/mcollective/plugin.d/` directory.  Note the directory `/etc/mcollective/plugin.d` is determined relative to the configuration file in use, if you were to use `/etc/puppetlabs/agent/mcollective/server.cfg` then `/etc/puppetlabs/agent/mcollective/plugin.d` would be consulted.
 
 To move a `plugin.<NAME>.<SETTING_NAME>` setting to an external file, put it in `/etc/mcollective/plugin.d/<NAME>.cfg`, and use only the `<SETTING_NAME>` segment of the setting. So this:
 

--- a/website/releasenotes.md
+++ b/website/releasenotes.md
@@ -8,6 +8,64 @@ This is a list of release notes for various releases, you should review these
 before upgrading as any potential problems and backward incompatible changes
 will be highlighted here.
 
+
+## 2.8.0 - 2015/02/04
+
+### New Features and Improvements from 2.7.0
+
+* Puppet Labs All-In-One Agent paths are now consulted in preference
+* core plugins now live in lib, are installed into sitelibdir
+* $libdir is now optional and extends the ruby $LOAD_PATH
+* rubocop policy violations now cause Travis CI build failures
+
+### Configuration path changes for Puppet Labs All-In-One Agent
+
+Client applications will now use the first readable config file of
+`~/.mcollective`, `/etc/puppetlabs/agent/mcollective/client.cfg`,
+`/etc/mcollective/client.cfg` when no configuration file is specified.
+
+The MCollective daemon will now use the first readable config file of
+`/etc/puppetlabs/agent/mcollective/server.cfg`,
+`/etc/mcollective/server.cfg` when no configuration file is specified.
+
+This is to support the forthcoming All-In-One Agent packages from
+Puppet Labs, which you can read about [here][aio].
+
+[aio]: https://groups.google.com/d/msg/puppet-dev/qZ-nOvmfrig/htvN7tyo_1YJ
+
+### $libdir/$LOAD_PATH changes and core plugins
+
+What would have been known as the core plugins now live alongside the
+core MCollective libraries and will be installed into ruby's
+sitelibdir on installation.
+
+In addition to this we have changed the behaviour of plugin loading so
+that all of ruby's $LOAD_PATH is consulted, the $libdir configuration
+file directive now works as a way to add entries to the start of this
+search path.
+
+The sum of these changes will make the mcollective-client gem usable
+as a self-contained client, just supply `~/.mcollective`.
+
+### Bug fixes since 2.7.0
+
+* Fixed crashing bug caused by interaction of autoload and threads
+* Fixed `mco facts` when no fact value is returned
+
+### Changes since 2.7.0
+
+|Date|Description|Ticket|
+|----|-----------|------|
+|2015/02/02|Add AIO init scripts to ext/aio|MCO-555|
+|2015/02/02|Move core plugins into sitelibdir|MCO-583|
+|2015/01/29|Prefer configuration files from AIO paths|MCO-560|
+|2015/01/29|Use $LOAD_PATH for loading plugins|MCO-315|
+|2015/01/28|Replace uses of `autoload` with `require`|MCO-580|
+|2015/01/21|Fix `mco facts` in absence of fact|MCO-558|
+|2015/01/07|Ensure rubocop failures fail the build|MCO-519|
+|2014/12/19|Fix powershell exit code interactions|MCO-550|
+
+
 <a name="2_7_0">&nbsp;</a>
 
 ## 2.7.0 - 2014/12/02


### PR DESCRIPTION
Here we update the changelog, releasenotes, and documentation to reflect the changes in the 2.8.0 release.