### PR TITLE
MCO-587 fix client gem loading

### DIFF
--- a/bin/mcollectived
+++ b/bin/mcollectived
@@ -5,6 +5,7 @@
 $LOAD_PATH.delete '.'
 
 require 'mcollective'
+require 'mcollective/runner'
 require 'getoptlong'
 
 opts = GetoptLong.new(

--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -49,7 +49,6 @@ module MCollective
   require "mcollective/pluginpackager"
   require "mcollective/registration"
   require "mcollective/rpc"
-  require "mcollective/runner"
   require "mcollective/runnerstats"
   require "mcollective/security"
   require "mcollective/shell"

--- a/spec/unit/mcollective/runner_spec.rb
+++ b/spec/unit/mcollective/runner_spec.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env rspec
 
 require 'spec_helper'
+require 'mcollective/runner'
 
 module MCollective
   describe Runner do


### PR DESCRIPTION
In MCO-580 6bdc58f97 we changed all the autoloads for requires, overlooking
that the mcollective-client gem witholds `lib/mcollective/runner.rb`.  This
causes the gem to to unusable as the require of 'mcollective/runner' can not be
resolved in a clean install.

Here we move the require out to the only users of MCollective::Runner, its unit
tests and the mcollectived script.