### PR TITLE
(PUP-3982) Fix condrestart on debian for AIO agent

### DIFF
--- a/ext/aio/debian/mcollective.init
+++ b/ext/aio/debian/mcollective.init
@@ -56,7 +56,6 @@ case "$1" in
         start-stop-daemon -S -p ${pidfile} --oknodo -q -a ${mcollectived} -- ${daemonopts} --daemonize
         [ $? = 0 ] && { exit 0 ; } || { exit 1 ; }
         log_success_msg "mcollective started"
-        touch $lock
         ;;
     stop)
         echo "Stopping daemon: " $name
@@ -72,11 +71,8 @@ case "$1" in
         [ $? = 0 ] && { echo "mcollective restarted" ; exit 0 ; }
         ;;
     condrestart)
-        if [ -f $lock ]; then
-            $0 stop
-            # avoid race
-            sleep 2
-            $0 start
+        if start-stop-daemon -T --oknodo -q -p ${pidfile}; then
+            $0 restart
         fi
         ;;
     force-reload)


### PR DESCRIPTION
condrestart was built around some sort of busted lock file
functionality. This changes it to rely on start-stop-daemon to
determine if the process is running or not.