### PR TITLE
(MCO-591) Fix condrestart on debian for AIO agent

### DIFF
--- a/ext/aio/debian/mcollective.init
+++ b/ext/aio/debian/mcollective.init
@@ -56,7 +56,6 @@ case "$1" in
         start-stop-daemon -S -p ${pidfile} --oknodo -q -a ${mcollectived} -- ${daemonopts} --daemonize
         [ $? = 0 ] && { exit 0 ; } || { exit 1 ; }
         log_success_msg "mcollective started"
-        touch $lock
         ;;
     stop)
         echo "Stopping daemon: " $name
@@ -72,11 +71,10 @@ case "$1" in
         [ $? = 0 ] && { echo "mcollective restarted" ; exit 0 ; }
         ;;
     condrestart)
-        if [ -f $lock ]; then
-            $0 stop
-            # avoid race
-            sleep 2
-            $0 start
+        # status prints a horrible error message when it fails. We
+        # don't want to scare the user away.
+        if $0 status >/dev/null 2>&1; then
+            $0 restart
         fi
         ;;
     force-reload)

--- a/ext/aio/debian/mcollective.init
+++ b/ext/aio/debian/mcollective.init
@@ -53,13 +53,13 @@ case "$1" in
     start)
         echo "Starting daemon: " $name
         # start the program
-        start-stop-daemon -S -p ${pidfile} --oknodo -q -a ${mcollectived} -- ${daemonopts} --daemonize
+        start-stop-daemon --start --pidfile ${pidfile} --oknodo --quiet --startas ${mcollectived} -- ${daemonopts} --daemonize
         [ $? = 0 ] && { exit 0 ; } || { exit 1 ; }
         log_success_msg "mcollective started"
         ;;
     stop)
         echo "Stopping daemon: " $name
-        start-stop-daemon -K -R 5 -s "TERM" --oknodo -q -p ${pidfile}
+        start-stop-daemon --stop --retry 5 --signal "TERM" --oknodo --quiet --pidfile ${pidfile}
         [ $? = 0 ] && { exit 0 ; } || { exit 1 ; }
         log_success_msg "mcollective stopped"
         ;;


### PR DESCRIPTION
condrestart was built around some sort of busted lock file
functionality. This changes it to rely on start-stop-daemon to
determine if the process is running or not.