### PR TITLE
Fix warning on mcollective start-up when running under systemd

### DIFF
--- a/ext/redhat/mcollective.service
+++ b/ext/redhat/mcollective.service
@@ -3,10 +3,10 @@ Description=The Marionette Collective
 After=network.target
 
 [Service]
-Type=forking
+Type=simple
 StandardOutput=syslog
 StandardError=syslog
-ExecStart=/usr/sbin/mcollectived --config=/etc/mcollective/server.cfg --pidfile=/var/run/mcollective.pid --daemonize
+ExecStart=/usr/sbin/mcollectived --config=/etc/mcollective/server.cfg --pidfile=/var/run/mcollective.pid --no-daemonize
 ExecReload=/bin/kill -USR1 $MAINPID
 PIDFile=/var/run/mcollective.pid
 


### PR DESCRIPTION
When starting mcollective under systemd on CentOS 7 I was seeing this
message:

Feb 11 00:35:07 ip-10-169-74-156 systemd: Starting The Marionette Collective...
Feb 11 00:35:08 ip-10-169-74-156 systemd: mcollective.service: Supervising process 6520 which is not our child. We'll most likely not notice when it exits.
Feb 11 00:35:08 ip-10-169-74-156 systemd: Started The Marionette Collective.

This was because mcollectived was configured to daemonize and the
systemd unit file specified a "forking" service.

It is better to not daemonize services under systemd as it enabled them
to be more reliably monitored.

This PR converts the mcollective systemd service to type "simple" and doesn't
daemonize the mcollectived daemon on startup.