### PR TITLE
MCO-594 Update for latest AIO paths

### DIFF
--- a/bin/mcollectived
+++ b/bin/mcollectived
@@ -22,7 +22,7 @@ if MCollective::Util.windows?
   configfile = File.join(MCollective::Util.windows_prefix, "etc", "server.cfg")
 else
   # search for the server.cfg in the AIO path then the traditional one
-  configfiles = ['/etc/puppetlabs/agent/mcollective/server.cfg',
+  configfiles = ['/etc/puppetlabs/mcollective/server.cfg',
                  '/etc/mcollective/server.cfg' ]
 
   found = configfiles.find_index { |file| File.readable?(file) }

--- a/ext/aio/common/client.cfg.dist
+++ b/ext/aio/common/client.cfg.dist
@@ -1,6 +1,6 @@
 main_collective = mcollective
 collectives = mcollective
-libdir = /opt/puppetlabs/agent/plugins
+libdir = /opt/puppetlabs/mcollective/plugins
 logger_type = console
 loglevel = warn
 

--- a/ext/aio/common/server.cfg.dist
+++ b/ext/aio/common/server.cfg.dist
@@ -1,7 +1,7 @@
 main_collective = mcollective
 collectives = mcollective
-libdir = /opt/puppetlabs/agent/plugins
-logfile = /var/log/puppetlabs/agent/mcollective.log
+libdir = /opt/puppetlabs/mcollective/plugins
+logfile = /var/log/puppetlabs/mcollective.log
 loglevel = info
 daemonize = 1
 
@@ -18,4 +18,4 @@ plugin.activemq.pool.1.password = marionette
 
 # Facts
 factsource = yaml
-plugin.yaml = /etc/puppetlabs/agent/mcollective/facts.yaml
+plugin.yaml = /etc/puppetlabs/mcollective/facts.yaml

--- a/ext/aio/debian/mcollective.init
+++ b/ext/aio/debian/mcollective.init
@@ -24,11 +24,11 @@ uid=`id -u`
 
 
 # PID directory
-pidfile="/var/run/puppetlabs/agent/mcollectived.pid"
+pidfile="/var/run/puppetlabs/mcollectived.pid"
 
 name="mcollective"
-mcollectived=/opt/puppetlabs/agent/bin/mcollectived
-daemonopts="--pid=${pidfile} --config=/etc/puppetlabs/agent/mcollective/server.cfg"
+mcollectived=/opt/puppetlabs/puppet/bin/mcollectived
+daemonopts="--pid=${pidfile} --config=/etc/puppetlabs/mcollective/server.cfg"
 
 
 # Source function library.

--- a/ext/aio/redhat/mcollective-systemd.logrotate
+++ b/ext/aio/redhat/mcollective-systemd.logrotate
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/agent/mcollective.log {
+/var/log/puppetlabs/mcollective.log {
     missingok
     notifempty
     sharedscripts

--- a/ext/aio/redhat/mcollective-sysv.logrotate
+++ b/ext/aio/redhat/mcollective-sysv.logrotate
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/agent/mcollective.log {
+/var/log/puppetlabs/mcollective.log {
     missingok
     notifempty
     sharedscripts

--- a/ext/aio/redhat/mcollective.init
+++ b/ext/aio/redhat/mcollective.init
@@ -16,8 +16,8 @@
 # Description:       Enable service provided by daemon.
 ### END INIT INFO
 
-mcollectived="/opt/puppetlabs/agent/bin/mcollectived"
-pidfile="/var/run/puppetlabs/agent/mcollectived.pid"
+mcollectived="/opt/puppetlabs/puppet/bin/mcollectived"
+pidfile="/var/run/puppetlabs/mcollectived.pid"
 if [ -d /var/lock/subsys ]; then
     # RedHat/CentOS/etc who use subsys
     lockfile="/var/lock/subsys/mcollective"
@@ -50,7 +50,7 @@ start() {
     echo -n "Starting mcollective: "
     # Only try to start if not already started
     if ! rh_status_q; then
-      daemon ${daemonopts} ${mcollectived} --pid=${pidfile} --config="/etc/puppetlabs/agent/mcollective/server.cfg" --daemonize
+      daemon ${daemonopts} ${mcollectived} --pid=${pidfile} --config="/etc/puppetlabs/mcollective/server.cfg" --daemonize
     fi
     # This will be 0 if mcollective is already running
     RETVAL=$?

--- a/ext/aio/redhat/mcollective.service
+++ b/ext/aio/redhat/mcollective.service
@@ -6,9 +6,9 @@ After=network.target
 Type=forking
 StandardOutput=syslog
 StandardError=syslog
-ExecStart=/opt/puppetlabs/agent/bin/mcollectived --config=/etc/puppetlabs/agent/mcollective/server.cfg --pidfile=/var/run/puppetlabs/agent/mcollective.pid --daemonize
+ExecStart=/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --pidfile=/var/run/puppetlabs/mcollective.pid --daemonize
 ExecReload=/bin/kill -USR1 $MAINPID
-PIDFile=/var/run/puppetlabs/agent/mcollective.pid
+PIDFile=/var/run/puppetlabs/mcollective.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/ext/aio/suse/mcollective.init
+++ b/ext/aio/suse/mcollective.init
@@ -30,9 +30,9 @@
 [ -f /etc/sysconfig/mcollective ] && . /etc/sysconfig/mcollective
 
 desc=${DESC:-mcollective daemon}
-daemon=${DAEMON:-/opt/puppetlabs/agent/bin/mcollectived}
+daemon=${DAEMON:-/opt/puppetlabs/puppet/bin/mcollectived}
 name=${NAME:-mcollectived}
-pidfile=${PIDFILE:-/var/run/puppetlabs/agent/mcollectived.pid}
+pidfile=${PIDFILE:-/var/run/puppetlabs/mcollectived.pid}
 daemon_opts=${DAEMON_OPTS:---pid ${pidfile}}
 
 # First reset status of this service

--- a/lib/mcollective/util.rb
+++ b/lib/mcollective/util.rb
@@ -170,7 +170,7 @@ module MCollective
       if self.windows?
         config_paths << File.join(self.windows_prefix, 'etc', 'client.cfg')
       else
-        config_paths << '/etc/puppetlabs/agent/mcollective/client.cfg'
+        config_paths << '/etc/puppetlabs/mcollective/client.cfg'
         config_paths << '/etc/mcollective/client.cfg'
       end
 

--- a/spec/unit/mcollective/util_spec.rb
+++ b/spec/unit/mcollective/util_spec.rb
@@ -200,8 +200,8 @@ module MCollective
         Util.stubs(:windows?).returns(false)
       end
 
-      it 'should default to /etc/puppetlabs/agent/mcollective/client.cfg if ~/.mcollective can not be expanded' do
-        Util.config_file_for_user.should == '/etc/puppetlabs/agent/mcollective/client.cfg'
+      it 'should default to /etc/puppetlabs/mcollective/client.cfg if ~/.mcollective can not be expanded' do
+        Util.config_file_for_user.should == '/etc/puppetlabs/mcollective/client.cfg'
       end
 
       it 'should default to ~/.mcollective if it can be expanded' do


### PR DESCRIPTION
The latest version of the Unified Puppet Agent Layout calls for config files in
/etc/puppetlabs/$project/$project.conf, logfiles in
/var/log/puppetlabs/$project.log, pidfiles in /var/run/puppetlabs/$project.pid,
binaries in /opt/puppetlabs/puppet/bin and user plugins for MCollective in
/opt/puppetlabs/mcollective/plugins.

Here we make those changes.