### PR TITLE
(maint) update plugin paths post MCO-583

### DIFF
--- a/website/reference/basic/messageformat.md
+++ b/website/reference/basic/messageformat.md
@@ -2,7 +2,7 @@
 layout: default
 title: Message Format
 ---
-[SecurityPlugins]: http://github.com/puppetlabs/marionette-collective/tree/master/plugins/mcollective/security/
+[SecurityPlugins]: http://github.com/puppetlabs/marionette-collective/tree/master/lib/mcollective/security/
 [SimpleRPCIntroduction]: /mcollective/simplerpc/
 [MessageFlow]: messageflow.html
 [ScreenCast]: /mcollective/screencasts.html#message_flow

--- a/website/reference/plugins/aggregate.md
+++ b/website/reference/plugins/aggregate.md
@@ -3,7 +3,7 @@ layout: default
 title: Aggregate Plugins
 ---
 [DDL]: /mcollective/reference/plugins/ddl.html
-[Examples]: https://github.com/puppetlabs/marionette-collective/tree/master/plugins/mcollective/aggregate
+[Examples]: https://github.com/puppetlabs/marionette-collective/tree/master/lib/mcollective/aggregate
 
 ## Overview
 MCollective Agents return data and we try to provide as much usable user
@@ -365,5 +365,3 @@ end
 Add the last few lines - we check that we're running in a version of MCollective
 that supports this feature and then we call our function with the *:exitcode*
 results.
-
-


### PR DESCRIPTION
Some of the documentation for extension points refers to core
plugins.  These moved as part of MCO-583 but the documentation was
overlooked.  Here we update those links.