### PR TITLE
(maint) specify a default connection_timeout

### DIFF
--- a/ext/aio/common/client.cfg.dist
+++ b/ext/aio/common/client.cfg.dist
@@ -14,3 +14,5 @@ plugin.activemq.pool.1.host = stomp1
 plugin.activemq.pool.1.port = 6163
 plugin.activemq.pool.1.user = mcollective
 plugin.activemq.pool.1.password = marionette
+
+connection_timeout = 3


### PR DESCRIPTION
If the middleware is down, or unreachable (which it's very likely to be for
stomp1:6163 as it's just placeholder) the client will just sit and wait which
is a poor first impression.  Add connection_timeout to the example config file,
so a user won't sit wondering why `mco ping` in an unconfigured environment
simply waits.