### PR TITLE
MCO-617 Assign version in-tree

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -6,7 +6,6 @@ homepage: 'https://docs.puppetlabs.com/mcollective/'
 summary: 'Application Server for hosting Ruby code on any capable middleware'
 description: 'The Marionette Collective, e.g. mcollective, is a framework for building server orchestration or parallel job execution systems.'
 version_file: 'lib/mcollective.rb'
-update_version_file: true
 # files and gem_files are space separated lists
 files: 'mcollective.init COPYING doc etc lib plugins ext bin install.rb'
 # List of packaging related templates to evaluate before the tarball is packed

--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="@DEVELOPMENT_VERSION@"
+  VERSION="2.8.0"
 
   def self.version
     VERSION

--- a/lib/mcollective/ddl/base.rb
+++ b/lib/mcollective/ddl/base.rb
@@ -100,11 +100,6 @@ module MCollective
 
       def validate_requirements
         if requirement = @requirements[:mcollective]
-          if Util.mcollective_version == "@DEVELOPMENT_VERSION@"
-            Log.warn("DDL requirements validation being skipped in development")
-            return true
-          end
-
           if Util.versioncmp(Util.mcollective_version, requirement) < 0
             raise DDLValidationError, "%s plugin '%s' requires MCollective version %s or newer" % [@plugintype.to_s.capitalize, @pluginname, requirement]
           end

--- a/spec/unit/mcollective/ddl/base_spec.rb
+++ b/spec/unit/mcollective/ddl/base_spec.rb
@@ -207,12 +207,6 @@ module MCollective
           @ddl.requires(:mcollective => "0.1")
           @ddl.validate_requirements.should == true
         end
-
-        it "should bypass checks in development" do
-          Util.stubs(:mcollective_version).returns("@DEVELOPMENT_VERSION@")
-          Log.expects(:warn).with(regexp_matches(/skipped in development/))
-          @ddl.requires(:mcollective => "0.1")
-        end
       end
 
       describe "#loaddlfile" do


### PR DESCRIPTION
Here we change version assignment from a release machinery task to a manual one, for consistency with other PuppetLabs projects.