### PR TITLE
(maint) remove version_file from project_data

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -5,7 +5,6 @@ email: 'info@puppetlabs.com'
 homepage: 'https://docs.puppetlabs.com/mcollective/'
 summary: 'Application Server for hosting Ruby code on any capable middleware'
 description: 'The Marionette Collective, e.g. mcollective, is a framework for building server orchestration or parallel job execution systems.'
-version_file: 'lib/mcollective.rb'
 # files and gem_files are space separated lists
 files: 'mcollective.init COPYING doc etc lib plugins ext bin install.rb'
 # List of packaging related templates to evaluate before the tarball is packed


### PR DESCRIPTION
As noted by @haus on PR#300, the removal of `update_version_file` also implies
we no longer need the `version_file` key in project_data.

https://github.com/puppetlabs/marionette-collective/pull/300#discussion-diff-25886614