### PR TITLE
(RE-3977) Remove runlevel 4 from Default-Start for SUSE

### DIFF
--- a/ext/aio/suse/mcollective.init
+++ b/ext/aio/suse/mcollective.init
@@ -12,8 +12,8 @@
 # Provides:          mcollective
 # Required-Start:    $remote_fs
 # Required-Stop:     $remote_fs
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
+# Default-Start:     3 5
+# Default-Stop:      0 1 2 6
 # Short-Description: Start daemon at boot time
 # Description:       Enable service provided by daemon.
 ### END INIT INFO


### PR DESCRIPTION
Apparently runlevel 4 is not used on SUSE, so we remove
it from Default-Start. We also move runlevel 2 to
Default-Stop for consistency with our puppet packaging.