### PR TITLE
(maint) pin systemu on ruby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,12 @@ source 'https://rubygems.org'
 
 gem 'json'
 gem 'stomp'
-gem 'systemu'
+
+if RUBY_VERSION =~ /^1.8/
+  gem 'systemu', '2.6.4'
+else
+  gem 'systemu'
+end
 
 group :dev do
   gem 'rake'


### PR DESCRIPTION
As per https://github.com/ahoward/systemu/issues/41 systemu's ruby
support policy is "whatever Ruby version is officially supported
at the point in time of the release"

For 1.8 pin to systemu 2.6.4, which is the last known working version
for 1.8