### PR TITLE
[DO NOT MERGE](MCO-625) mco.bat should use ruby instead of %RUBY%

### DIFF
--- a/ext/windows/mco.bat
+++ b/ext/windows/mco.bat
@@ -4,4 +4,4 @@ SETLOCAL
 
 call "%~dp0environment.bat" %0 %*
 
-%RUBY% -S -- mco %* --config "%CLIENT_CONFIG%"
+ruby -S -- mco %* --config "%CLIENT_CONFIG%"


### PR DESCRIPTION
The `mco.bat` file built with the MSI uses `%RUBY%` rather than `ruby`
used by `puppet.bat` or `facter.bat`. This environmental variable
does not appear to be set in `environment.bat`.

This causes calls to `mco` on Windows to return the following error:

```
C:\Users\Administrator>"C:\Program Files\Puppet Labs\Puppet\bin\mco.bat" ping
'-S' is not recognized as an internal or external command, operable program
or batch file.
```

Other bat files used by the puppet agent do not display this similar
behavior. Fix up mco.bat to use ruby instead of %RUBY%. Without this
change, calls to `mco` on Windows will continue to fail.