### PR TITLE
MCO-647 downgrade libdir warning

### DIFF
--- a/bin/mco
+++ b/bin/mco
@@ -15,6 +15,12 @@ if $0 =~ /mc\-([a-zA-Z\-_\.]+)$/
 else
   app_name = ARGV.first
   ARGV.delete_at(0)
+
+  # it may be a config option rather than an application name.  In this
+  # case pretend we had no application name
+  if app_name =~ /^--/
+    app_name = nil
+  end
 end
 
 if known_applications.include?(app_name)
@@ -25,8 +31,17 @@ if known_applications.include?(app_name)
 else
   puts "The Marionette Collective version #{MCollective.version}"
   puts
-  puts "usage: #{$0} command <options>"
-  puts
+
+  if app_name
+    puts "Unknown command '#{app_name}', searched for applications in:"
+    puts
+    puts MCollective::Config.instance.libdir.map { |path| "   #{path}\n" }
+    puts
+  else
+    puts "usage: #{$0} command <options>"
+    puts
+  end
+
   puts "Known commands:"
   puts
 

--- a/lib/mcollective/config.rb
+++ b/lib/mcollective/config.rb
@@ -145,7 +145,7 @@ module MCollective
 
         libdirs.each do |dir|
           unless File.directory?(dir)
-            Log.warn("Cannot find libdir: #{dir}")
+            Log.debug("Cannot find libdir: #{dir}")
           end
 
           # remove the old one if it exists, we're moving it to the front


### PR DESCRIPTION
Here we downgrade the warning from pointing to a non-existent libdir to a debug message, and make the error raised by a missing application namecheck the application searched for and the paths searched.