### PR TITLE
MCO-641 add the 'classic' libdirs to aio sample config

### DIFF
--- a/ext/aio/common/client.cfg.dist
+++ b/ext/aio/common/client.cfg.dist
@@ -1,6 +1,12 @@
 main_collective = mcollective
 collectives = mcollective
+
 libdir = /opt/puppetlabs/mcollective/plugins
+
+# consult the "classic" libdirs too
+libdir = /usr/share/mcollective/plugins
+libdir = /usr/libexec/mcollective
+
 logger_type = console
 loglevel = warn
 

--- a/ext/aio/common/server.cfg.dist
+++ b/ext/aio/common/server.cfg.dist
@@ -1,6 +1,12 @@
 main_collective = mcollective
 collectives = mcollective
+
 libdir = /opt/puppetlabs/mcollective/plugins
+
+# consult the "classic" libdirs too
+libdir = /usr/share/mcollective/plugins
+libdir = /usr/libexec/mcollective
+
 logfile = /var/log/puppetlabs/mcollective.log
 loglevel = info
 daemonize = 1


### PR DESCRIPTION
Here we add the two divergent 'default' libdirs from the pre-aio repathing as
search paths to the example configuration file.  This demonstrates the ability
to consult the classic paths in addition to the new standard pathing.