### PR TITLE
MCO-640 exit nonzero if a command can not be found

### DIFF
--- a/bin/mco
+++ b/bin/mco
@@ -6,6 +6,9 @@ $LOAD_PATH.delete '.'
 
 require 'mcollective'
 
+# assume everything will all be fine
+exitcode = 0
+
 Version = MCollective.version
 known_applications = MCollective::Applications.list
 
@@ -37,6 +40,9 @@ else
     puts
     puts MCollective::Config.instance.libdir.map { |path| "   #{path}\n" }
     puts
+
+    # exit with an error as we didn't find a command
+    exitcode = 1
   else
     puts "usage: #{$0} command <options>"
     puts
@@ -54,3 +60,5 @@ else
   puts "to get detailed help for a command"
   puts
 end
+
+exit exitcode


### PR DESCRIPTION
Here we change the exitcode of `mco somecommand` when `somecommand` can not be
found to indicate the error condition of a missing application.