### PR TITLE
(MAINT) Add mco_master role to acceptance

### DIFF
--- a/acceptance/config/nodes/centos-5-x86_64.yaml
+++ b/acceptance/config/nodes/centos-5-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: centos-5-x86_64
     hypervisor: vcloud
     template: centos-5-x86_64

--- a/acceptance/config/nodes/centos-6-x86_64.yaml
+++ b/acceptance/config/nodes/centos-6-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: centos-6-x86_64
     hypervisor: vcloud
     template: centos-6-x86_64

--- a/acceptance/config/nodes/debian-6-x86_64.yaml
+++ b/acceptance/config/nodes/debian-6-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: debian-squeeze-x86_64
     hypervisor: vcloud
     template: debian-6-x86_64

--- a/acceptance/config/nodes/debian-7-x86_64.yaml
+++ b/acceptance/config/nodes/debian-7-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: debian-wheezy-x86_64
     hypervisor: vcloud
     template: debian-7-x86_64

--- a/acceptance/config/nodes/debian-8-x86_64.yaml
+++ b/acceptance/config/nodes/debian-8-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: debian-jessie-x86_64
     hypervisor: vcloud
     template: debian-8-x86_64

--- a/acceptance/config/nodes/fedora-20-x86_64.yaml
+++ b/acceptance/config/nodes/fedora-20-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: fedora-20-x86_64
     hypervisor: vcloud
     template: fedora-20-x86_64

--- a/acceptance/config/nodes/fedora-21-x86_64.yaml
+++ b/acceptance/config/nodes/fedora-21-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: fedora-21-x86_64
     hypervisor: vcloud
     template: fedora-21-x86_64

--- a/acceptance/config/nodes/redhat-5-x86_64.yaml
+++ b/acceptance/config/nodes/redhat-5-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: el-5-x86_64
     hypervisor: vcloud
     template: redhat-5-x86_64

--- a/acceptance/config/nodes/redhat-6-x86_64.yaml
+++ b/acceptance/config/nodes/redhat-6-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: el-6-x86_64
     hypervisor: vcloud
     template: redhat-6-x86_64

--- a/acceptance/config/nodes/redhat-7-x86_64.yaml
+++ b/acceptance/config/nodes/redhat-7-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: el-7-x86_64
     hypervisor: vcloud
     template: redhat-7-x86_64

--- a/acceptance/config/nodes/ubuntu-1204-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1204-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: ubuntu-precise-x86_64
     hypervisor: vcloud
     template: ubuntu-1204-x86_64

--- a/acceptance/config/nodes/ubuntu-1404-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1404-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: ubuntu-trusty-x86_64
     hypervisor: vcloud
     template: ubuntu-1404-x86_64

--- a/acceptance/config/nodes/ubuntu-1410-x86_64.yaml
+++ b/acceptance/config/nodes/ubuntu-1410-x86_64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent:
     roles:
     - agent
+    - mco_master
     platform: ubuntu-utopic-x86_64
     hypervisor: vcloud
     template: ubuntu-1410-x86_64

--- a/acceptance/config/nodes/win2003r2x64-rubyx64.yaml
+++ b/acceptance/config/nodes/win2003r2x64-rubyx64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2003r2-x86_64-rubyx64:
     roles:
     - agent
+    - mco_master
     platform: windows-2003r2-64
     ruby_arch: x64
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2003r2x64-rubyx86.yaml
+++ b/acceptance/config/nodes/win2003r2x64-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2003r2-x86_64-rubyx86:
     roles:
     - agent
+    - mco_master
     platform: windows-2003r2-64
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2003r2x86-rubyx86.yaml
+++ b/acceptance/config/nodes/win2003r2x86-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2003r2-i386:
     roles:
     - agent
+    - mco_master
     platform: windows-2003r2-32
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2003x64-rubyx64.yaml
+++ b/acceptance/config/nodes/win2003x64-rubyx64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2003-x86_64-rubyx64:
     roles:
     - agent
+    - mco_master
     platform: windows-2003-64
     ruby_arch: x64
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2003x64-rubyx86.yaml
+++ b/acceptance/config/nodes/win2003x64-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2003-x86_64-rubyx86:
     roles:
     - agent
+    - mco_master
     platform: windows-2003-64
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2003x86-rubyx86.yaml
+++ b/acceptance/config/nodes/win2003x86-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2003-i386:
     roles:
     - agent
+    - mco_master
     platform: windows-2003-32
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2008-rubyx64.yaml
+++ b/acceptance/config/nodes/win2008-rubyx64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2008-x86_64-rubyx64:
     roles:
     - agent
+    - mco_master
     platform: windows-2008-64
     ruby_arch: x64
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2008-rubyx86.yaml
+++ b/acceptance/config/nodes/win2008-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2008-x86_64-rubyx86:
     roles:
     - agent
+    - mco_master
     platform: windows-2008-64
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2008r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2008r2-rubyx64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2008r2-x86_64-rubyx64:
     roles:
     - agent
+    - mco_master
     platform: windows-2008r2-64
     ruby_arch: x64
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2008r2-rubyx86.yaml
+++ b/acceptance/config/nodes/win2008r2-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2008r2-x86_64-rubyx86:
     roles:
     - agent
+    - mco_master
     platform: windows-2008r2-64
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2012-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012-rubyx64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2012-x86_64-rubyx64:
     roles:
     - agent
+    - mco_master
     platform: windows-2012-64
     ruby_arch: x64
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2012-rubyx86.yaml
+++ b/acceptance/config/nodes/win2012-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2012-x86_64-rubyx86:
     roles:
     - agent
+    - mco_master
     platform: windows-2012-64
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2012r2-rubyx64.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx64.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2012r2-x86_64-rubyx64:
     roles:
     - agent
+    - mco_master
     platform: windows-2012r2-64
     ruby_arch: x64
     hypervisor: vcloud

--- a/acceptance/config/nodes/win2012r2-rubyx86.yaml
+++ b/acceptance/config/nodes/win2012r2-rubyx86.yaml
@@ -9,6 +9,7 @@ HOSTS:
   agent-2012r2-x86_64-rubyx86:
     roles:
     - agent
+    - mco_master
     platform: windows-2012r2-64
     ruby_arch: x86
     hypervisor: vcloud

--- a/acceptance/setup/aio/pre-suite/060_Install-activemq.rb
+++ b/acceptance/setup/aio/pre-suite/060_Install-activemq.rb
@@ -1,28 +1,28 @@
 test_name 'install activemq' do
   amq_version = '5.11.1'
   # install activemq, copy config and trust/keystore
-  if agent.platform =~ /el-|centos/ then
-    install_package agent, 'java-1.7.0-openjdk'
-    curl_on(agent, "-O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
-    on(agent, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
+  if mco_master.platform =~ /el-|centos/ then
+    install_package mco_master, 'java-1.7.0-openjdk'
+    curl_on(mco_master, "-O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
+    on(mco_master, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
     activemq_confdir = "/opt/apache-activemq-#{amq_version}/conf"
-  elsif agent.platform =~/ubuntu|debian/ then
-    install_package agent, 'openjdk-7-jdk'
-    curl_on(agent, "-O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
-    on(agent, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
+  elsif mco_master.platform =~/ubuntu|debian/ then
+    install_package mco_master, 'openjdk-7-jdk'
+    curl_on(mco_master, "-O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
+    on(mco_master, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
     activemq_confdir = "/opt/apache-activemq-#{amq_version}/conf"
-  elsif agent.platform =~/windows/ then
+  elsif mco_master.platform =~/windows/ then
 
     step "Windows - Install Oracle JDK"
     oracle_base_url = 'https://download.oracle.com/otn-pub/java/jdk'
     jdk_version_full = '8u45-b14'
     jdk_version, jdk_build = jdk_version_full.split('-')
-    if agent[:ruby_arch] == 'x64' then
+    if mco_master[:ruby_arch] == 'x64' then
       jdk_arch = 'x64'
     else
       jdk_arch = 'i586'
     end
-    if agent.platform =~ /2003/ then
+    if mco_master.platform =~ /2003/ then
       fail_test "Sorry, this test pre-suite does not yet support Windows 2003"
       admin_dir = 'Documents\ and\ Settings/Administrator'
     else
@@ -30,9 +30,9 @@ test_name 'install activemq' do
     end
     jdk_exe = "jdk-#{jdk_version}-windows-#{jdk_arch}.exe"
 
-    curl_on(agent, "-k -L -O -H 'Cookie: oraclelicense=accept-securebackup-cookie'  '#{oracle_base_url}/#{jdk_version_full}/#{jdk_exe}'")
+    curl_on(mco_master, "-k -L -O -H 'Cookie: oraclelicense=accept-securebackup-cookie'  '#{oracle_base_url}/#{jdk_version_full}/#{jdk_exe}'")
 
-    on(agent, "mv #{jdk_exe} /cygdrive/c/#{admin_dir}/")
+    on(mco_master, "mv #{jdk_exe} /cygdrive/c/#{admin_dir}/")
     manifest = <<EOS
     file { 'C:/#{admin_dir}/#{jdk_exe}':
       mode => '0777',
@@ -44,90 +44,148 @@ test_name 'install activemq' do
       install_options => ['INSTALLDIR=C:\\java', 'STATIC=1', '/s'],
     }
 EOS
-    apply_manifest_on(agent, manifest)
+    apply_manifest_on(mco_master, manifest)
 
     step "Windows - Add JAVA_HOME environmental variable"
-    agent.add_env_var('JAVA_HOME','C:\java')
+    mco_master.add_env_var('JAVA_HOME','C:\java')
 
     step "Windows - Add java/bin to PATH environmental variable"
-    agent.add_env_var('PATH', 'C:\java\bin')
+    mco_master.add_env_var('PATH', 'C:\java\bin')
 
     step "Windows - Install activemq"
-    file_path = agent.tmpfile('activemq.zip')
-    curl_on(agent, "-o #{file_path}.zip http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.zip")
-    on(agent, puppet("module install reidmv-unzip"))
+    file_path = mco_master.tmpfile('activemq.zip')
+    curl_on(mco_master, "-o #{file_path}.zip http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.zip")
+    on(mco_master, puppet("module install reidmv-unzip"))
     manifest = <<EOS
     unzip { "activemq":
       source  => '#{file_path}.zip',
       creates => 'C:/apache-activemq-#{amq_version}',
     }
 EOS
-    apply_manifest_on(agent, manifest)
+    apply_manifest_on(mco_master, manifest)
 
     step "Windows - Add ACTIVEMQ_HOME environmental variable"
-    agent.add_env_var('ACTIVEMQ_HOME',"C:\\apache-activemq-#{amq_version}")
+    mco_master.add_env_var('ACTIVEMQ_HOME',"C:\\apache-activemq-#{amq_version}")
     activemq_confdir = "C:/apache-activemq-#{amq_version}/conf"
     # ///END Windows install
   else
-    install_package agent, 'activemq'
+    install_package mco_master, 'activemq'
     activemq_confdir = "/etc/activemq"
   end
 
   step "Setup activemq config files"
-  unless agent.platform =~/windows/ then
+  unless mco_master.platform =~/windows/ then
     mco_confdir = "/etc/puppetlabs/mcollective"
   else
     mco_confdir = "C:/ProgramData/PuppetLabs/mcollective/etc"
   end
 
-  scp_to agent, 'files/activemq.xml', "#{activemq_confdir}/activemq.xml"
-  scp_to agent, 'files/activemq.truststore', "#{activemq_confdir}/activemq.truststore"
-  scp_to agent, 'files/activemq.keystore', "#{activemq_confdir}/activemq.keystore"
+  scp_to mco_master, 'files/activemq.xml', "#{activemq_confdir}/activemq.xml"
+  scp_to mco_master, 'files/activemq.truststore', "#{activemq_confdir}/activemq.truststore"
+  scp_to mco_master, 'files/activemq.keystore', "#{activemq_confdir}/activemq.keystore"
 
   step "Start activemq"
-  if agent.platform =~ /el-|centos|ubuntu|debian/ then
-    on agent, "cd /opt/apache-activemq-#{amq_version} && ./bin/activemq start"
-  elsif agent.platform =~/windows/ then
-    if agent[:ruby_arch] == 'x64' then
+  if mco_master.platform =~ /el-|centos|ubuntu|debian/ then
+    on mco_master, "cd /opt/apache-activemq-#{amq_version} && ./bin/activemq start"
+  elsif mco_master.platform =~/windows/ then
+    if mco_master[:ruby_arch] == 'x64' then
       amq_arch = 'win64'
     else
       amq_arch = 'win32'
     end
-    on agent, "C:/apache-activemq-#{amq_version}/bin/#{amq_arch}/InstallService.bat"
-    on agent, puppet('resource service activemq ensure=running')
+    on mco_master, "C:/apache-activemq-#{amq_version}/bin/#{amq_arch}/InstallService.bat"
+    on mco_master, puppet('resource service activemq ensure=running')
   else
-    on agent, 'service activemq start'
+    on mco_master, 'service activemq start'
   end
 
-  unless port_open_within?(agent, 61613, 300 )
+  unless port_open_within?(mco_master, 61613, 300 )
     raise Beaker::DSL::FailTest, 'Timed out trying to access ActiveMQ'
   end
 
+  ############################
   step "Setup mcollective config files"
-  unless agent.platform =~/windows/ then
-    scp_to agent, 'files/server.cfg', "#{mco_confdir}/server.cfg"
-    scp_to agent, 'files/client.cfg', "#{mco_confdir}/client.cfg"
+  unless mco_master.platform =~/windows/ then
+    scp_to mco_master, 'files/client.cfg', "#{mco_confdir}/client.cfg"
   else
-    scp_to agent, 'files/windows-server.cfg', "#{mco_confdir}/server.cfg"
-    scp_to agent, 'files/windows-client.cfg', "#{mco_confdir}/client.cfg"
+    scp_to mco_master, 'files/windows-client.cfg', "#{mco_confdir}/client.cfg"
   end
-  scp_to agent, 'files/ca_crt.pem', "#{mco_confdir}/ca_crt.pem"
-  scp_to agent, 'files/server.crt', "#{mco_confdir}/server.crt"
-  scp_to agent, 'files/server.key', "#{mco_confdir}/server.key"
-  scp_to agent, 'files/client.crt', "#{mco_confdir}/client.crt"
-  scp_to agent, 'files/client.key', "#{mco_confdir}/client.key"
+  hosts.each do |h|
 
-  on agent, "mkdir #{mco_confdir}/ssl-clients"
-  scp_to agent, 'files/client.crt', "#{mco_confdir}/ssl-clients/client.pem"
+    unless h.platform =~/windows/ then
+      mco_confdir = "/etc/puppetlabs/mcollective"
+      libdir = "/opt/puppetlabs/mcollective/plugins"
+      logdir = "/var/log/puppetlabs"
+      puppet_cmd = "/opt/puppetlabs/bin/puppet"
+      puppet_confdir = "/etc/puppetlabs/puppet"
+    else
+      mco_confdir = "C:/ProgramData/PuppetLabs/mcollective/etc"
+      libdir = "#{mco_confdir}/plugins"
+      logdir = "C:/ProgramData/PuppetLabs/mcollective/var/log"
+      puppet_cmd = "C:/Program Files/Puppet Labs\\Puppet\\bin\\puppet.bat"
+      puppet_confdir = "C:/ProgramData/PuppetLabs\\puppept\\etc\\puppet"
+    end
+
+
+    server_cfg =<<EOS
+main_collective = mcollective
+collectives = mcollective
+libdir = #{libdir}
+logfile = #{logdir}/mcollective.log
+loglevel = info
+daemonize = 1
+
+securityprovider = ssl
+plugin.ssl_server_private = #{mco_confdir}/server.key
+plugin.ssl_server_public = #{mco_confdir}/server.crt
+plugin.ssl_client_cert_dir = #{mco_confdir}/ssl-clients/
+
+connector = activemq
+plugin.activemq.pool.size = 1
+plugin.activemq.pool.1.host = #{mco_master}
+plugin.activemq.pool.1.port = 61613
+plugin.activemq.pool.1.user = mcollective
+plugin.activemq.pool.1.password = marionette
+plugin.activemq.pool.1.ssl = true
+plugin.activemq.pool.1.ssl.ca = #{mco_confdir}/ca_crt.pem
+plugin.activemq.pool.1.ssl.cert = #{mco_confdir}/server.crt
+plugin.activemq.pool.1.ssl.key = #{mco_confdir}/server.key
+
+# Facts
+factsource = yaml
+plugin.yaml = #{mco_confdir}/facts.yaml
+
+# Plugin settings for puppet-agent
+plugin.puppet.command = "#{puppet_cmd}" agent
+plugin.puppet.splay = true
+plugin.puppet.splaylimit = 30
+plugin.puppet.config = #{puppet_confdir}/puppet.conf
+plugin.puppet.windows_service = puppet
+plugin.puppet.signal_daemon = true
+EOS
+
+    create_remote_file(h,  "#{mco_confdir}/server.cfg", server_cfg)
+
+    scp_to h, 'files/ca_crt.pem', "#{mco_confdir}/ca_crt.pem"
+    scp_to h, 'files/server.crt', "#{mco_confdir}/server.crt"
+    scp_to h, 'files/server.key', "#{mco_confdir}/server.key"
+    scp_to h, 'files/client.crt', "#{mco_confdir}/client.crt"
+    scp_to h, 'files/client.key', "#{mco_confdir}/client.key"
+
+    on h, "mkdir #{mco_confdir}/ssl-clients"
+    scp_to h, 'files/client.crt', "#{mco_confdir}/ssl-clients/client.pem"
+  end
 
   step "Start mcollective service"
-  unless agent.platform =~/windows/ then
-    on agent, 'service mcollective restart'
-  else
-    on agent, puppet('resource service mcollective ensure=running')
+  hosts.each do |h|
+    unless h.platform =~/windows/ then
+      on h, 'service mcollective restart'
+    else
+      on h, puppet('resource service mcollective ensure=running')
+    end
   end
 
-  unless port_open_within?(agent, 61613, 300 )
+  unless port_open_within?(mco_master, 61613, 300 )
     raise Beaker::DSL::FailTest, 'Timed out trying to access ActiveMQ'
   end
 end

--- a/acceptance/setup/aio/pre-suite/070_Install_puppet-agent-plugin.rb
+++ b/acceptance/setup/aio/pre-suite/070_Install_puppet-agent-plugin.rb
@@ -1,26 +1,27 @@
 test_name 'install puppet-agent plugin' do
-  if agent.platform =~ /windows/ then
-   mco_libdir = 'C:/ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective'
-  else
-   mco_libdir = '/opt/puppetlabs/mcollective/plugins/mcollective'
-   git_pkg = 'git'
-   if agent.platform =~ /ubuntu-10/
-     git_pkg = 'git-core'
-   end
-   install_package(agent, git_pkg)
-  end
-  on agent, "mkdir -p #{mco_libdir}"
-  on agent, "git clone https://github.com/puppetlabs/mcollective-puppet-agent.git"
-  on agent, "cd mcollective-puppet-agent && for i in agent aggregate application data util validator ; do cp -a $i #{mco_libdir} ; done"
+  hosts.each do |h|
+    if h.platform =~ /windows/ then
+     mco_libdir = 'C:/ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective'
+    else
+     mco_libdir = '/opt/puppetlabs/mcollective/plugins/mcollective'
+     git_pkg = 'git'
+     if h.platform =~ /ubuntu-10/
+       git_pkg = 'git-core'
+     end
+     install_package(h, git_pkg)
+    end
+    on h, "mkdir -p #{mco_libdir}"
+    on h, "git clone https://github.com/puppetlabs/mcollective-puppet-agent.git"
+    on h, "cd mcollective-puppet-agent && for i in agent aggregate application data util validator ; do cp -a $i #{mco_libdir} ; done"
 
-  unless agent.platform =~/windows/ then
-    on agent, 'service mcollective restart'
-  else
-    on agent, puppet('resource service mcollective ensure=stopped')
-    on agent, puppet('resource service mcollective ensure=running')
+    unless h.platform =~/windows/ then
+      on h, 'service mcollective restart'
+    else
+      on h, puppet('resource service mcollective ensure=stopped')
+      on h, puppet('resource service mcollective ensure=running')
+    end
   end
-
-  unless port_open_within?(agent, 61613, 300 )
+  unless port_open_within?(mco_master, 61613, 300 )
     raise Beaker::DSL::FailTest, 'Timed out trying to access ActiveMQ'
   end
 end

--- a/acceptance/tests/mco_ping.rb
+++ b/acceptance/tests/mco_ping.rb
@@ -1,7 +1,7 @@
 test_name "mco ping" do
   step "run ping"
-    if agent.platform =~ /windows/ then
-      if agent[:ruby_arch] == 'x86' then
+    if mco_master.platform =~ /windows/ then
+      if mco_master[:ruby_arch] == 'x86' then
         mco_bin = 'cmd.exe /c C:/Program\ Files\ \(x86\)/Puppet\ Labs/Puppet/bin/mco.bat'
       else
         mco_bin = 'cmd.exe /c C:/Program\ Files/Puppet\ Labs/Puppet/bin/mco.bat'
@@ -9,8 +9,8 @@ test_name "mco ping" do
     else
      mco_bin = '/opt/puppetlabs/bin/mco'
     end
-    on(agent, "#{mco_bin} ping") do
+    on(mco_master, "#{mco_bin} ping") do
       assert_equal(0, exit_code)
-      assert_match(/^1\s+replies/, stdout)
+      assert_match(/^#{hosts.size}\s+replies/, stdout)
     end
 end

--- a/acceptance/tests/mco_puppet_count.rb
+++ b/acceptance/tests/mco_puppet_count.rb
@@ -1,7 +1,7 @@
 test_name "mco puppet count" do
   step "run puppet count"
-    if agent.platform =~ /windows/ then
-      if agent[:ruby_arch] == 'x86' then
+    if mco_master.platform =~ /windows/ then
+      if mco_master[:ruby_arch] == 'x86' then
         mco_bin = 'cmd.exe /c C:/Program\ Files\ \(x86\)/Puppet\ Labs/Puppet/bin/mco.bat'
       else
         mco_bin = 'cmd.exe /c C:/Program\ Files/Puppet\ Labs/Puppet/bin/mco.bat'
@@ -9,8 +9,8 @@ test_name "mco puppet count" do
     else
      mco_bin = '/opt/puppetlabs/bin/mco'
     end
-    on(agent, "#{mco_bin} puppet count") do
+    on(mco_master, "#{mco_bin} puppet count") do
       assert_equal(0, exit_code)
-      assert_match(/^Total Puppet nodes:\s+1/, stdout)
+      assert_match(/^Total Puppet nodes:\s+#{hosts.size}/, stdout)
     end
 end


### PR DESCRIPTION
This commit adds an `mco_master` role to the beaker host files,
as well as using this role in the tests and pre-suit files to
determine where to deploy the mco-broker infrastructure.

Since the `mco_master` role can be applied to any node in the
hosts lists, the `server.cfg` file has been added to the
`060_Install-activemq.rb` pre-suite step as a parameterized
HEREDOC string.