### PR TITLE
(DOC-2043): change mentions of faq@ to docs@puppetlabs.com

### DIFF
--- a/website/deploy/install.md
+++ b/website/deploy/install.md
@@ -269,5 +269,5 @@ Unlike with the official packages, you won't be able to count on sensible defaul
 Installing on Windows
 -----
 
-We currently have no instructions for installing MCollective on Windows. You should investigate the `ext/windows` directory in the MCollective source. If you've used MCollective on Windows, we'd love to hear about your experience, especially any unexpected pitfalls you ran into. Email <faq@puppetlabs.com>.
+We currently have no instructions for installing MCollective on Windows. You should investigate the `ext/windows` directory in the MCollective source. If you've used MCollective on Windows, we'd love to hear about your experience, especially any unexpected pitfalls you ran into. Email <docs@puppetlabs.com>.
 

--- a/website/deploy/middleware/activemq.md
+++ b/website/deploy/middleware/activemq.md
@@ -300,7 +300,7 @@ By default, ActiveMQ allows everyone to **read** from any topic or queue, **writ
 By setting rules in an `<authorizationPlugin>` element, you can regulate things a bit. Some notes:
 
 * Authorization is done **by group.**
-* The exact behavior of authorization doesn't seem to be documented anywhere. Going by observation, it appears that ActiveMQ first tries the most specific rule available, then retreats to less specific rules. This means if a given group isn't allowed an action by a more specific rule but is allowed it by a more general rule, it still gets authorized to take that action. If you have any solid information about how this works, please email us at <faq@puppetlabs.com>.
+* The exact behavior of authorization doesn't seem to be documented anywhere. Going by observation, it appears that ActiveMQ first tries the most specific rule available, then retreats to less specific rules. This means if a given group isn't allowed an action by a more specific rule but is allowed it by a more general rule, it still gets authorized to take that action. If you have any solid information about how this works, please email us at <docs@puppetlabs.com>.
 * MCollective creates subscriptions before it knows whether there will be any content coming. That means any role able to **read** from or **write** to a destination must also be able to **admin** that destination. Think of "admin" as a superset of both read and write.
 
 #### Simple Restrictions


### PR DESCRIPTION
Users reading the documentation have previously been directed to email faq@puppetlabs.com which sends a mass email to everyone on the faq list (which is most people in the company). Fixing this to point to our own documentation alias to cut down on excess emails. 