### PR TITLE
(RE-5032) fully qualify the label in the osx mco plist

### DIFF
--- a/ext/aio/osx/mcollective.plist
+++ b/ext/aio/osx/mcollective.plist
@@ -10,7 +10,7 @@
                 <string>en_US.UTF-8</string>
         </dict>
         <key>Label</key>
-        <string>mcollective</string>
+        <string>com.puppetlabs.mcollective</string>
         <key>KeepAlive</key>
         <true/>
         <key>ProgramArguments</key>


### PR DESCRIPTION
This commit fully qualifies the label in the osx mco plist using the
identifier plus service name.