### PR TITLE
update links to fuse docs - moved under access.redhat.com

### DIFF
--- a/README
+++ b/README
@@ -3,4 +3,4 @@ The Marionette Collective
 
 The Marionette Collective aka. mcollective is a framework to build server orchestration or parallel job execution systems.
 
-For full information, wikis, ticketing and downloads please see http://marionette-collective.org/
+For full information, wikis, ticketing and downloads please see https://puppetlabs.com/mcollective

--- a/website/deploy/middleware/activemq.md
+++ b/website/deploy/middleware/activemq.md
@@ -113,7 +113,7 @@ You can also read external documentation for a more complete understanding.
 The Apache ActiveMQ documentation contains important information, but it is often incomplete, badly organized, and confusing. The Fuse documentation (a commercially supported release of ActiveMQ) is significantly better written and better organized, although it requires signing up for an email newsletter, but it may be out of sync with the most recent ActiveMQ releases.
 
 * [Apache ActiveMQ Documentation][apache_activemq_config_docs]
-* [Fuse Documentation](http://fusesource.com/documentation/fuse-message-broker-documentation/)
+* [Fuse Documentation](https://access.redhat.com/documentation/en-US/Fuse_Message_Broker/)
 
 ### Wildcards
 
@@ -268,7 +268,7 @@ You set up authentication by adding the appropriate element to the `<plugins>` e
 - `jaasAuthenticationPlugin` lets you use external text files (or even an LDAP database) to define users and groups. You need to make a `login.config` file in the ActiveMQ config directory, and possibly two more files. You can add users and groups without restarting the broker. The external users file will contain sensitive passwords and must be protected.
 - `jaasCertificateAuthenticationPlugin` ignores the username and password that MCollective presents; instead, it reads the distinguished name of the certificate and maps that to a username. It requires TLS, a `login.config` file, and two other external files. It is also impractical unless your servers are all using the same SSL certificate to connect to ActiveMQ; the currently recommended approach of re-using Puppet certificates makes this problematic, but you can probably ship credentials around and figure out a way to make it work. This is not currently well-tested with MCollective.
 
-[fuse_security]: http://fusesource.com/docs/broker/5.5/security/front.html
+[fuse_security]: https://access.redhat.com/documentation/en-US/Fuse_Message_Broker/5.5/html/Security_Guide/files/front.html
 [activemq_security]: http://activemq.apache.org/security.html
 
 The example below uses `simpleAuthenticationPlugin`.
@@ -446,7 +446,7 @@ Designing your broker network's topology is beyond the scope of this reference. 
 * What kinds of traffic should be excluded from other brokers.
 
 [NetworksOfBrokers]: http://activemq.apache.org/networks-of-brokers.html
-[fuse_cluster]: http://fusesource.com/docs/broker/5.5/clustering/index.html
+[fuse_cluster]: https://access.redhat.com/documentation/en-US/Fuse_Message_Broker/5.5/html/Using_Networks_of_Brokers/files/front.html
 
 
 ### Broker Name
@@ -533,7 +533,7 @@ Notes:
 
 ### Destination Filtering
 
-[fuse_filtering]: http://fusesource.com/docs/broker/5.5/clustering/Networks-Filtering.html
+[fuse_filtering]: https://access.redhat.com/documentation/en-US/Fuse_Message_Broker/5.5/html/Using_Networks_of_Brokers/files/FMQNetworksDestinationFiltering.html
 
 _Optional._
 

--- a/website/reference/integration/activemq_clusters.md
+++ b/website/reference/integration/activemq_clusters.md
@@ -6,7 +6,7 @@ toc: false
 [MessageFlow]: /mcollective/reference/basic/messageflow.html
 [NetworksOfBrokers]: http://activemq.apache.org/networks-of-brokers.html
 [SampleConfig]: http://github.com/puppetlabs/marionette-collective/tree/master/ext/activemq/
-[fuse_cluster]: http://fusesource.com/docs/broker/5.5/clustering/index.html
+[fuse_cluster]: https://access.redhat.com/documentation/en-US/Fuse_Message_Broker/5.5/html/Using_Networks_of_Brokers/files/front.html
 [activemq_network]: /mcollective/deploy/middleware/activemq.html#settings-for-networks-of-brokers
 
 Relying on existing middleware tools and not re-inventing the transport wheel ourselves means we can take advantage of a lot of the built in features they provide.  One such feature is clustering in ActiveMQ that allows for highly scalable and flexible network layouts.


### PR DESCRIPTION
The Fuse docs have all moved from the fusesource.com domain to be under access.redhat.com. The actual pages seem to have moved around a bit as well. This PR updates the links to the fuse docs. 

It also updates the main URL for mcollective in the README to be http://puppetlabs.com/mcollective as it appears http://marionette-collective.org/ is no longer (or it's temporarily offline perhaps?)