### PR TITLE
(MCO-705) revert "(RE-5032) fully qualify the label in the osx mco pl…

### DIFF
--- a/ext/aio/osx/mcollective.plist
+++ b/ext/aio/osx/mcollective.plist
@@ -10,7 +10,7 @@
                 <string>en_US.UTF-8</string>
         </dict>
         <key>Label</key>
-        <string>com.puppetlabs.mcollective</string>
+        <string>mcollective</string>
         <key>KeepAlive</key>
         <true/>
         <key>ProgramArguments</key>


### PR DESCRIPTION
…ist"

Reverts puppetlabs/marionette-collective#328

We realized that changing this name actually changes the service name,
which impacts anyone trying to manage the service - such as PE. This
seems high-impact for a patch release.