### PR TITLE
(maint) Fix Solaris SMF service for mcollective for AIO

### DIFF
--- a/ext/aio/solaris/smf/mcollective.xml
+++ b/ext/aio/solaris/smf/mcollective.xml
@@ -24,7 +24,7 @@
       <service_fmri value="svc:/system/filesystem/local"/>
     </dependency>
 
-    <exec_method type="method" name="start" exec="/opt/puppetlabs/bin/mcollectived --pid=/var/run/puppetlabs/mcollective.pid --config=/etc/puppetlabs/mcollective/server.cfg" timeout_seconds="60"/>
+    <exec_method type="method" name="start" exec="/opt/puppetlabs/puppet/bin/mcollectived --pid=/var/run/puppetlabs/mcollective.pid --config=/etc/puppetlabs/mcollective/server.cfg" timeout_seconds="60"/>
 
     <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
 


### PR DESCRIPTION
Prior to this commit, mcollective service startup
with the Solaris AIO puppet-agent fails because the
SMF manifest is using the non-AIO path to mcollectived.

This commit updates the Solaris SMF service manifest
to use the correct AIO path to mcollectived.