### PR TITLE
(MCO-726) Prepare for 2.8.6 release

### DIFF
--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="2.8.5"
+  VERSION="2.8.6"
 
   def self.version
     VERSION

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -8,6 +8,8 @@ toc: false
 
 |Date|Description|Ticket|
 |----|-----------|------|
+|2015/09/15|Release *2.8.6*|MCO-726|
+|2015/09/11|Fix solaris smf service manifest for aio|(#345)[https://github.com/puppetlabs/marionette-collective/pull/345]|
 |2015/09/10|Release *2.8.5*|MCO-724|
 |2015/08/25|Add condrestart to the suse init script for AIO|RE-11690|
 |2015/08/21|Release *2.8.4*|MCO-706|

--- a/website/releasenotes.md
+++ b/website/releasenotes.md
@@ -8,6 +8,22 @@ This is a list of release notes for various releases, you should review these
 before upgrading as any potential problems and backward incompatible changes
 will be highlighted here.
 
+
+<a name="2_8_6">&nbsp;</a>
+
+## 2.8.6 - 2015/09/15
+
+### Changes since 2.8.5
+
+* Fixed an issue with the solaris smf service in AIO. The service manifest listed the
+daemon binary in the wrong location (/opt/puppetlabs/bin as opposed to
+/opt/puppetlabs/puppet/bin)
+
+|Date|Description|Ticket|
+|----|-----------|------|
+|2015/09/11|Fix solaris smf service manifest for aio|(#345)[https://github.com/puppetlabs/marionette-collective/pull/345]|
+
+
 <a name="2_8_5">&nbsp;</a>
 
 ## 2.8.5 - 2015/09/10


### PR DESCRIPTION
Bump the version and update the changelog and readme for 2.8.6 release