### PR TITLE
(docs) Update or fix links, especially to plugins.

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -8,7 +8,7 @@ releaseable state.  In doing this we use the following branches.
 `master` is the main development branch, it is where you should be
 targetting your changes by default.
  
-Our documentation on http://docs.puppetlabs.com/mcollective is built
+Our documentation on https://docs.puppetlabs.com/mcollective is built
 from the /website directory of `master`, so if you are making changes
 that change documented behaviour please take care to mention if the
 feature is unreleased.

--- a/acceptance/files/activemq.xml
+++ b/acceptance/files/activemq.xml
@@ -100,7 +100,7 @@
             mcollective, which can both issue and respond to commands. For an
             example that splits permissions and doesn't allow servers to issue
             commands, see:
-            http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
+            https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
           -->
           <authorizationPlugin>
             <map>

--- a/ext/action_helpers/perl/lib/MCollective/Action.pm
+++ b/ext/action_helpers/perl/lib/MCollective/Action.pm
@@ -152,7 +152,7 @@ and/or modify it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 
-http://docs.puppetlabs.com/mcollective/
+https://docs.puppetlabs.com/mcollective/
 
 =cut
 

--- a/ext/activemq/examples/multi-broker/broker1-activemq.xml
+++ b/ext/activemq/examples/multi-broker/broker1-activemq.xml
@@ -14,7 +14,7 @@
 
     <!--
       For more information about what MCollective requires in this file,
-      see http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+      see https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
     -->
 
     <!--
@@ -156,7 +156,7 @@
             mcollective, which can both issue and respond to commands. For an
             example that splits permissions and doesn't allow servers to issue
             commands, see:
-            http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
+            https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
           -->
           <authorizationPlugin>
             <map>
@@ -180,7 +180,7 @@
         <!--
           The systemUsage controls the maximum amount of space the broker will
           use for messages. For more information, see:
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
         -->
         <systemUsage>
             <systemUsage>
@@ -202,7 +202,7 @@
           use OpenWire. You'll need different URLs depending on whether you are
           using TLS. For more information, see:
 
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
         -->
         <transportConnectors>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>

--- a/ext/activemq/examples/multi-broker/broker2-activemq.xml
+++ b/ext/activemq/examples/multi-broker/broker2-activemq.xml
@@ -14,7 +14,7 @@
 
     <!--
       For more information about what MCollective requires in this file,
-      see http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+      see https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
     -->
 
     <!--
@@ -87,7 +87,7 @@
             mcollective, which can both issue and respond to commands. For an
             example that splits permissions and doesn't allow servers to issue
             commands, see:
-            http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
+            https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
           -->
           <authorizationPlugin>
             <map>
@@ -111,7 +111,7 @@
         <!--
           The systemUsage controls the maximum amount of space the broker will
           use for messages. For more information, see:
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
         -->
         <systemUsage>
             <systemUsage>
@@ -133,7 +133,7 @@
           use OpenWire. You'll need different URLs depending on whether you are
           using TLS. For more information, see:
 
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
         -->
         <transportConnectors>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>

--- a/ext/activemq/examples/multi-broker/broker3-activemq.xml
+++ b/ext/activemq/examples/multi-broker/broker3-activemq.xml
@@ -14,7 +14,7 @@
 
     <!--
       For more information about what MCollective requires in this file,
-      see http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+      see https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
     -->
 
     <!--
@@ -87,7 +87,7 @@
             mcollective, which can both issue and respond to commands. For an
             example that splits permissions and doesn't allow servers to issue
             commands, see:
-            http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
+            https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
           -->
           <authorizationPlugin>
             <map>
@@ -111,7 +111,7 @@
         <!--
           The systemUsage controls the maximum amount of space the broker will
           use for messages. For more information, see:
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
         -->
         <systemUsage>
             <systemUsage>
@@ -133,7 +133,7 @@
           use OpenWire. You'll need different URLs depending on whether you are
           using TLS. For more information, see:
 
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
         -->
         <transportConnectors>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>

--- a/ext/activemq/examples/single-broker/activemq.xml
+++ b/ext/activemq/examples/single-broker/activemq.xml
@@ -14,7 +14,7 @@
 
     <!--
       For more information about what MCollective requires in this file,
-      see http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+      see https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
     -->
 
     <!--
@@ -70,7 +70,7 @@
             mcollective, which can both issue and respond to commands. For an
             example that splits permissions and doesn't allow servers to issue
             commands, see:
-            http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
+            https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#detailed-restrictions
           -->
           <authorizationPlugin>
             <map>
@@ -94,7 +94,7 @@
         <!--
           The systemUsage controls the maximum amount of space the broker will
           use for messages. For more information, see:
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#memory-and-temp-usage-for-messages-systemusage
         -->
         <systemUsage>
             <systemUsage>
@@ -116,7 +116,7 @@
           use OpenWire. You'll need different URLs depending on whether you are
           using TLS. For more information, see:
 
-          http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
+          https://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html#transport-connectors
         -->
         <transportConnectors>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>

--- a/ext/debian/control
+++ b/ext/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: Riccardo Setti <giskard@debian.org>
 Build-Depends: debhelper (>= 7), quilt, cdbs, ruby
 Standards-Version: 3.8.0
-Homepage: http://marionette-collective.org/
+Homepage: https://docs.puppetlabs.com/mcollective/
 
 Package: mcollective
 Architecture: all

--- a/lib/mcollective/agent/discovery.rb
+++ b/lib/mcollective/agent/discovery.rb
@@ -15,7 +15,7 @@ module MCollective
                  :timeout => @timeout,
                  :name => "Discovery Agent",
                  :version => MCollective.version,
-                 :url => "http://www.marionette-collective.org",
+                 :url => "https://docs.puppetlabs.com/mcollective/",
                  :description => "MCollective Discovery Agent"}
       end
 

--- a/lib/mcollective/agent/rpcutil.ddl
+++ b/lib/mcollective/agent/rpcutil.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "rpcutil",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "Apache License, Version 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 10
 
 action "collective_info", :description => "Info about the main and sub collectives" do

--- a/lib/mcollective/aggregate/average.ddl
+++ b/lib/mcollective/aggregate/average.ddl
@@ -3,7 +3,7 @@ metadata  :name        => "average",
           :author      => "Pieter Loubser <pieter.loubser@puppetlabs.com>",
           :license     => "ASL 2.0",
           :version     => "1.0",
-          :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
+          :url         => "https://docs.puppetlabs.com/mcollective/plugin_directory/",
           :timeout     => 5
 
 usage <<-USAGE

--- a/lib/mcollective/aggregate/sum.ddl
+++ b/lib/mcollective/aggregate/sum.ddl
@@ -3,7 +3,7 @@ metadata  :name        => "Sum",
           :author      => "Pieter Loubser <pieter.loubser@puppetlabs.com>",
           :license     => "ASL 2.0",
           :version     => "1.0",
-          :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
+          :url         => "https://docs.puppetlabs.com/mcollective/plugin_directory/",
           :timeout     => 5
 
 usage <<-USAGE

--- a/lib/mcollective/aggregate/summary.ddl
+++ b/lib/mcollective/aggregate/summary.ddl
@@ -3,7 +3,7 @@ metadata  :name        => "summary",
           :author      => "Pieter Loubser <pieter.loubser@puppetlabs.com>",
           :license     => "ASL 2.0",
           :version     => "1.0",
-          :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
+          :url         => "https://docs.puppetlabs.com/mcollective/plugin_directory/",
           :timeout     => 5
 
 usage <<-USAGE

--- a/lib/mcollective/connector/activemq.ddl
+++ b/lib/mcollective/connector/activemq.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "ActiveMQ Connector",
             :author      => "Puppet Labs",
             :license     => "ASL 2.0",
             :version     => "1.0.0",
-            :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
+            :url         => "https://docs.puppetlabs.com/mcollective/plugin_directory/",
             :timeout     => 60
 
 requires :mcollective => "2.6.0"

--- a/lib/mcollective/connector/rabbitmq.ddl
+++ b/lib/mcollective/connector/rabbitmq.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "RabbitMQ Connector",
             :author      => "Puppet Labs",
             :license     => "ASL 2.0",
             :version     => "1.0.0",
-            :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
+            :url         => "https://docs.puppetlabs.com/mcollective/plugin_directory/",
             :timeout     => 60
 
 requires :mcollective => "2.6.0"

--- a/lib/mcollective/data/agent_data.ddl
+++ b/lib/mcollective/data/agent_data.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "Agent",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1
 
 dataquery :description => "Agent Meta Data" do

--- a/lib/mcollective/data/collective_data.ddl
+++ b/lib/mcollective/data/collective_data.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "Collective",
             :author      => "Puppet Labs",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1
 
 dataquery :description => "Collective" do

--- a/lib/mcollective/data/fact_data.ddl
+++ b/lib/mcollective/data/fact_data.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "Fact",
             :author      => "Puppet Labs",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1
 
 dataquery :description => "Fact" do

--- a/lib/mcollective/data/fstat_data.ddl
+++ b/lib/mcollective/data/fstat_data.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "File Stat",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1
 
 dataquery :description => "File stat information" do

--- a/lib/mcollective/ddl/agentddl.rb
+++ b/lib/mcollective/ddl/agentddl.rb
@@ -9,7 +9,7 @@ module MCollective
     #             :author      => "R.I.Pienaar <rip@devco.net>",
     #             :license     => "Apache License, Version 2.0",
     #             :version     => "1.0",
-    #             :url         => "http://marionette-collective.org/",
+    #             :url         => "https://docs.puppetlabs.com/mcollective/",
     #             :timeout     => 10
     #
     # action "get_fact", :description => "Retrieve a single fact from the fact store" do

--- a/lib/mcollective/ddl/dataddl.rb
+++ b/lib/mcollective/ddl/dataddl.rb
@@ -10,7 +10,7 @@ module MCollective
     #             :author      => "R.I.Pienaar <rip@devco.net>",
     #             :license     => "ASL 2.0",
     #             :version     => "1.0",
-    #             :url         => "http://marionette-collective.org/",
+    #             :url         => "https://docs.puppetlabs.com/mcollective/",
     #             :timeout     => 1
     #
     # dataquery :description => "Agent Meta Data" do

--- a/lib/mcollective/ddl/discoveryddl.rb
+++ b/lib/mcollective/ddl/discoveryddl.rb
@@ -7,7 +7,7 @@ module MCollective
     #             :author      => "R.I.Pienaar <rip@devco.net>",
     #             :license     => "ASL 2.0",
     #             :version     => "0.1",
-    #             :url         => "http://marionette-collective.org/",
+    #             :url         => "https://docs.puppetlabs.com/mcollective/",
     #             :timeout     => 2
     #
     # discovery do

--- a/lib/mcollective/discovery/flatfile.ddl
+++ b/lib/mcollective/discovery/flatfile.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "flatfile",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "ASL 2.0",
             :version     => "0.1",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 0
 
 discovery do

--- a/lib/mcollective/discovery/mc.ddl
+++ b/lib/mcollective/discovery/mc.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "mc",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "ASL 2.0",
             :version     => "0.1",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 2
 
 discovery do

--- a/lib/mcollective/discovery/stdin.ddl
+++ b/lib/mcollective/discovery/stdin.ddl
@@ -3,7 +3,7 @@ metadata    :name        => "stdin",
             :author      => "Tomas Doran <bobtfish@bobtfish.net.net>",
             :license     => "ASL 2.0",
             :version     => "0.1",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 0
 
 discovery do

--- a/lib/mcollective/rpc/agent.rb
+++ b/lib/mcollective/rpc/agent.rb
@@ -4,7 +4,7 @@ module MCollective
     # you would do for each agent allowing you to just create methods following a naming
     # standard leaving the heavy lifting up to this clas.
     #
-    # See http://marionette-collective.org/simplerpc/agents.html
+    # See https://docs.puppetlabs.com/mcollective/simplerpc/agents.html
     #
     # It only really makes sense to use this with a Simple RPC client on the other end, basic
     # usage would be:

--- a/lib/mcollective/validator/array_validator.ddl
+++ b/lib/mcollective/validator/array_validator.ddl
@@ -3,5 +3,5 @@ metadata    :name        => "Array",
             :author      => "P. Loubser <pieter.loubser@puppetlabs.com>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1

--- a/lib/mcollective/validator/ipv4address_validator.ddl
+++ b/lib/mcollective/validator/ipv4address_validator.ddl
@@ -3,5 +3,5 @@ metadata    :name        => "IPv4 Address",
             :author      => "P. Loubser <pieter.loubser@puppetlabs.com>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1

--- a/lib/mcollective/validator/ipv6address_validator.ddl
+++ b/lib/mcollective/validator/ipv6address_validator.ddl
@@ -3,5 +3,5 @@ metadata    :name        => "IPv6 Address",
             :author      => "P. Loubser <pieter.loubser@puppetlabs.com>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1

--- a/lib/mcollective/validator/length_validator.ddl
+++ b/lib/mcollective/validator/length_validator.ddl
@@ -3,5 +3,5 @@ metadata    :name        => "Length",
             :author      => "P. Loubser <pieter.loubser@puppetlabs.com>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1

--- a/lib/mcollective/validator/regex_validator.ddl
+++ b/lib/mcollective/validator/regex_validator.ddl
@@ -3,5 +3,5 @@ metadata    :name        => "Regex",
             :author      => "P. Loubser <pieter.loubser@puppetlabs.com>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1

--- a/lib/mcollective/validator/shellsafe_validator.ddl
+++ b/lib/mcollective/validator/shellsafe_validator.ddl
@@ -3,5 +3,5 @@ metadata    :name        => "Shellsafe",
             :author      => "P. Loubser <pieter.loubser@puppetlabs.com>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1

--- a/lib/mcollective/validator/typecheck_validator.ddl
+++ b/lib/mcollective/validator/typecheck_validator.ddl
@@ -3,5 +3,5 @@ metadata    :name        => "Typecheck",
             :author      => "P. Loubser <pieter.loubser@puppetlabs.com>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1

--- a/website/configure/server.md
+++ b/website/configure/server.md
@@ -6,14 +6,14 @@ layout: default
 
 [middleware]: /mcollective/deploy/middleware/
 [filters]: /mcollective/reference/ui/filters.html
-[plugin_directory]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki
+[plugin_directory]: https://docs.puppetlabs.com/mcollective/plugin_directory/
 [subcollectives]: /mcollective/reference/basic/subcollectives.html
 [registration]: /mcollective/reference/plugins/registration.html
 [puppetdb]: /puppetdb/
 [security_plugin]: #security-plugin-settings
 [auditing]: /mcollective/simplerpc/auditing.html
 [authorization]: /mcollective/simplerpc/authorization.html
-[actionpolicy]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AuthorizationActionPolicy
+[actionpolicy]: https://docs.puppetlabs.com/mcollective/plugin_directory/authorization_action_policy.html
 [security_aes]: /mcollective/reference/plugins/security_aes.html
 [security_overview]: /mcollective/security.html
 [ssl_plugin]: /mcollective/reference/plugins/security_ssl.html

--- a/website/deploy/install.md
+++ b/website/deploy/install.md
@@ -175,8 +175,8 @@ The example below uses a modified pattern. It assumes:
       }
 
       # Restart the service when any settings change
-      # (see http://docs.puppetlabs.com/puppet/latest/reference/lang_collectors.html and
-      # http://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html#chaining-arrows
+      # (see https://docs.puppetlabs.com/puppet/latest/reference/lang_collectors.html and
+      # https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html#chaining-arrows
       # for syntax details)
       Package['mcollective'] -> Mcollective::Setting <| |> ~> Service['mcollective']
     }

--- a/website/deploy/plugins.md
+++ b/website/deploy/plugins.md
@@ -316,7 +316,7 @@ Determining the amount of hosts matching filter for 2 seconds .... 1
 
 some.node:
    Agents:
-        [{:url=>"http://marionette-collective.org/",
+        [{:url=>"https://docs.puppetlabs.com/mcollective/",
           :version=>"1.0",
           :name=>"Utilities and Helpers for SimpleRPC Agents",
           :agent=>"rpcutil",
@@ -343,7 +343,7 @@ General helpful actions that expose stats and internals to SimpleRPC clients
      Version: 1.0
      License: Apache License, Version 2.0
      Timeout: 3
-   Home Page: http://marionette-collective.org/
+   Home Page: https://docs.puppetlabs.com/mcollective/
 
 
 

--- a/website/deploy/standard.md
+++ b/website/deploy/standard.md
@@ -25,7 +25,7 @@ layout: default
 [puppet_template]: /guides/templating.html
 [puppet_lang_notification]: /puppet/latest/reference/lang_relationships.html#ordering-and-notification
 [file]: /references/latest/type.html#file
-[actionpolicy_docs]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AuthorizationActionPolicy
+[actionpolicy_docs]: https://docs.puppetlabs.com/mcollective/plugin_directory/authorization_action_policy.html
 [actionpolicy]: https://github.com/puppetlabs/mcollective-actionpolicy-auth
 [server_config]: /mcollective/configure/server.html
 [client_config]: /mcollective/configure/client.html
@@ -534,7 +534,7 @@ For more information on how to install these agents, [see "Installing and Packag
     * [Installing plugins by copying into the libdir][plugin_libdir]
 
 [agent_writing]: /mcollective/simplerpc/agents.html
-[mcollective_plugins_wiki]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki
+[mcollective_plugins_wiki]: https://docs.puppetlabs.com/mcollective/plugin_directory/
 
 ### Learn MCollective's Command Line Interface
 

--- a/website/index.md
+++ b/website/index.md
@@ -9,10 +9,10 @@ toc: false
 [Amazon EC2 based demo]: /mcollective/ec2demo.html
 [broadcast paradigm]: /mcollective/reference/basic/messageflow.html
 [UsingWithPuppet]: /mcollective/reference/integration/puppet.html
-[Facter]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/FactsFacterYAML
+[Facter]: https://docs.puppetlabs.com/mcollective/plugin_directory/facter_via_yaml.html
 [WritingFactsPlugins]: /mcollective/reference/plugins/facts.html
 [NodeReports]: /mcollective/reference/ui/nodereports.html
-[PluginsSite]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki
+[PluginsSite]: https://docs.puppetlabs.com/mcollective/plugin_directory/
 [SimpleRPCIntroduction]: /mcollective/simplerpc/
 [SecurityOverview]: /mcollective/security.html
 [SecurityWithActiveMQ]: /mcollective/reference/integration/activemq_security.html

--- a/website/overview_components.md
+++ b/website/overview_components.md
@@ -9,7 +9,7 @@ layout: default
 [standard_deploy]: /mcollective/deploy/standard.html
 [agents]: /mcollective/simplerpc/agents.html
 [subcollectives]: /mcollective/reference/basic/subcollectives.html
-[actionpolicy]: https://github.com/puppetlabs/mcollective-actionpolicy-auth#readme
+[actionpolicy]: https://docs.puppetlabs.com/mcollective/plugin_directory/authorization_action_policy.html
 [ssl_plugin]: /mcollective/reference/plugins/security_ssl.html
 [psk_plugin]: /mcollective/configure/server.html#psk-plugin-settings
 [aes_plugin]: /mcollective/reference/plugins/security_aes.html

--- a/website/plugin_directory/agent_registration_mongodb.markdown
+++ b/website/plugin_directory/agent_registration_mongodb.markdown
@@ -19,7 +19,7 @@ Installation
 
 You need to have the following installed:
 
- * The [registration metadata](registration_metadata.html)  plugin and [Registration](http://docs.puppetlabs.com/mcollective/reference/plugins/registration.html) should be set up.
+ * The [registration metadata](registration_metadata.html)  plugin and [Registration](https://docs.puppetlabs.com/mcollective/reference/plugins/registration.html) should be set up.
  * A copy of [MongoDB](http://mongodb.org/) up and running
  * The [Mongo Ruby](http://www.mongodb.org/display/DOCS/Ruby+Language+Center) extension
  * The source is on [GitHub](https://github.com/puppetlabs/mcollective-plugins/tree/master/agent/registration-mongodb/)

--- a/website/plugin_directory/agent_registration_monitor.markdown
+++ b/website/plugin_directory/agent_registration_monitor.markdown
@@ -3,7 +3,7 @@ layout: default
 title: "MCollective Plugin: Agent Registration Monitor"
 ---
 
-MCollective supports sending [registration messages](http://docs.puppetlabs.com/mcollective/reference/plugins/registration.html) at set intervals. This is an agent to receive those messages and simply write the content to a file per sender.
+MCollective supports sending [registration messages](https://docs.puppetlabs.com/mcollective/reference/plugins/registration.html) at set intervals. This is an agent to receive those messages and simply write the content to a file per sender.
 
 It includes a Nagios check that monitors the directory with these files for any that has not checked in for some time.
 

--- a/website/plugin_directory/central_rpc_log.markdown
+++ b/website/plugin_directory/central_rpc_log.markdown
@@ -4,7 +4,7 @@ title: "MCollective Plugin: Central RPC Audit Log"
 ---
 
 
-This is a [SimpleRPC Audit Plugin](http://docs.puppetlabs.com/mcollective/simplerpc/auditing.html) and Agent that sends all SimpleRPC audit events to a central point for logging.
+This is a [SimpleRPC Audit Plugin](https://docs.puppetlabs.com/mcollective/simplerpc/auditing.html) and Agent that sends all SimpleRPC audit events to a central point for logging.
 
 You'd run the audit plugin on every node and designate one node as the receiver of audit logs.  The receiver will have a detailed log of every SimpleRPC request processed on your entire server estate.
 

--- a/website/plugin_directory/registration_metadata.markdown
+++ b/website/plugin_directory/registration_metadata.markdown
@@ -18,7 +18,7 @@ Installation
 Configuration
 -----
 
-For full details about the registration system see [Registration](http://docs.puppetlabs.com/mcollective/reference/plugins/registration.html)
+For full details about the registration system see [Registration](https://docs.puppetlabs.com/mcollective/reference/plugins/registration.html)
 
 The simplest configuration for this plugin is:
 

--- a/website/reference/basic/gettingstarted.md
+++ b/website/reference/basic/gettingstarted.md
@@ -21,7 +21,7 @@ title: Getting Started
 [ConnectorActiveMQ]: /mcollective/reference/plugins/connector_activemq.html
 [ConnectorRabbitMQ]: /mcollective/reference/plugins/connector_rabbitmq.html
 [MessageFlowCast]: /mcollective/screencasts.html#message_flow
-[Plugins]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki
+[Plugins]: https://docs.puppetlabs.com/mcollective/plugin_directory/
 [RedHatGuide]: gettingstarted_redhat.html
 [DebianGuide]: gettingstarted_debian.html
 [server_config]: /mcollective/configure/server.html

--- a/website/reference/basic/gettingstarted_debian.md
+++ b/website/reference/basic/gettingstarted_debian.md
@@ -22,7 +22,7 @@ title: Getting Started
 [ConnectorActiveMQ]: /mcollective/reference/plugins/connector_activemq.html
 [ConnectorRabbitMQ]: /mcollective/reference/plugins/connector_rabbitmq.html
 [MessageFlowCast]: /mcollective/screencasts.html#message_flow
-[Plugins]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki
+[Plugins]: https://docs.puppetlabs.com/mcollective/plugin_directory/
 [MCDownloads]: http://www.puppetlabs.com/downloads/mcollective/
 [RubyGems]: http://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=rubygems
 [server_config]: /mcollective/configure/server.html

--- a/website/reference/basic/gettingstarted_redhat.md
+++ b/website/reference/basic/gettingstarted_redhat.md
@@ -21,7 +21,7 @@ title: Getting Started
 [ConnectorActiveMQ]: /mcollective/reference/plugins/connector_activemq.html
 [ConnectorRabbitMQ]: /mcollective/reference/plugins/connector_rabbitmq.html
 [MessageFlowCast]: /mcollective/screencasts.html#message_flow
-[Plugins]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki
+[Plugins]: https://docs.puppetlabs.com/mcollective/plugin_directory/
 [MCDownloads]: http://www.puppetlabs.com/downloads/mcollective/
 [EPEL]: http://fedoraproject.org/wiki/EPEL
 [server_config]: /mcollective/configure/server.html

--- a/website/reference/index.md
+++ b/website/reference/index.md
@@ -47,7 +47,7 @@ Index to basic users documentation.
  1. [Stomp Connector](plugins/connector_stomp.html)
  1. [ActiveMQ Connector](plugins/connector_activemq.html)
  1. [RabbitMQ Connector](plugins/connector_rabbitmq.html)
- 1. [User Contributed Plugins](http://projects.puppetlabs.com/projects/mcollective-plugins/wiki)
+ 1. [User Contributed Plugins](plugin_directory/)
 
 ### Development
 

--- a/website/reference/integration/puppet.md
+++ b/website/reference/integration/puppet.md
@@ -3,9 +3,9 @@ layout: default
 title: Using with Puppet
 toc: false
 ---
-[FactsRLFacter]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/FactsFacterYAML
+[FactsRLFacter]: https://docs.puppetlabs.com/mcollective/plugin_directory/facter_via_yaml.html
 [PluginSync]: http://docs.reductivelabs.com/guides/plugins_in_modules.html
-[AgentPuppetd]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AgentPuppetd
+[AgentPuppetd]: https://docs.puppetlabs.com/mcollective/plugin_directory/puppet_agent.html
 [AgentPuppetca]: http://github.com/puppetlabs/mcollective-plugins/tree/master/agent/puppetca/
 [AgentPuppetRal]: http://github.com/puppetlabs/mcollective-plugins/tree/master/agent/puppetral/
 [PuppetCommander]: http://github.com/puppetlabs/mcollective-plugins/tree/master/agent/puppetd/commander/
@@ -15,8 +15,8 @@ toc: false
 [SchedulingPuppet]: http://www.devco.net/archives/2010/03/17/scheduling_puppet_with_mcollective.php
 [ManagingPuppetd]: http://www.devco.net/archives/2009/11/30/managing_puppetd_with_mcollective.php
 [CloudBootstrap]: http://vuksan.com/blog/2010/07/28/bootstraping-your-cloud-environment-with-puppet-and-mcollective/
-[ServiceAgent]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AgentService
-[PackageAgent]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AgentPackage
+[ServiceAgent]: https://docs.puppetlabs.com/mcollective/plugin_directory/services.html
+[PackageAgent]: https://docs.puppetlabs.com/mcollective/plugin_directory/package.html
 [Facter2YAML]: http://www.semicomplete.com/blog/geekery/puppet-facts-into-mcollective.html
 
 If you're a Puppet user you are supported in both facts and classes filters.

--- a/website/reference/plugins/data.md
+++ b/website/reference/plugins/data.md
@@ -163,7 +163,7 @@ metadata    :name        => "Sysctl values",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "ASL 2.0",
             :version     => "1.0",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 1
 
 dataquery :description => "Sysctl values" do
@@ -236,7 +236,7 @@ Retrieve values for a given sysctl
      Version: 1.0
      License: ASL 2.0
      Timeout: 1
-   Home Page: http://marionette-collective.org/
+   Home Page: https://docs.puppetlabs.com/mcollective/
 
 QUERY FUNCTION INPUT:
 

--- a/website/reference/plugins/ddl.md
+++ b/website/reference/plugins/ddl.md
@@ -45,7 +45,7 @@ metadata :name        => "service",
          :author      => "R.I.Pienaar",
          :license     => "GPLv2",
          :version     => "1.1",
-         :url         => "http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
+         :url         => "https://docs.puppetlabs.com/mcollective/plugin_directory/",
          :timeout     => 60
 {% endhighlight %}
 
@@ -129,7 +129,7 @@ Agent to manage services using the Puppet service provider
      Version: 1.1
      License: GPLv2
      Timeout: 60
-   Home Page: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki
+   Home Page: https://docs.puppetlabs.com/mcollective/plugin_directory/
 
 
 
@@ -241,7 +241,7 @@ Meta Data:
  :name=>"service",
  :timeout=>60,
  :version=>"1.1",
- :url=>"http://projects.puppetlabs.com/projects/mcollective-plugins/wiki",
+ :url=>"https://docs.puppetlabs.com/mcollective/plugin_directory/",
  :description=>"Agent to manage services using the Puppet service provider"}
 
 Status Action:

--- a/website/reference/plugins/discovery.md
+++ b/website/reference/plugins/discovery.md
@@ -50,7 +50,7 @@ Flatfile based discovery for node identities
      Version: 0.1
      License: ASL 2.0
      Timeout: 0
-   Home Page: http://marionette-collective.org/
+   Home Page: https://docs.puppetlabs.com/mcollective/
 
 DISCOVERY METHOD CAPABILITIES:
       Filter based on mcollective identity
@@ -143,7 +143,7 @@ metadata    :name        => "flatfile",
             :author      => "R.I.Pienaar <rip@devco.net>",
             :license     => "ASL 2.0",
             :version     => "0.1",
-            :url         => "http://marionette-collective.org/",
+            :url         => "https://docs.puppetlabs.com/mcollective/",
             :timeout     => 0
 
 discovery do

--- a/website/reference/plugins/registration.md
+++ b/website/reference/plugins/registration.md
@@ -3,7 +3,7 @@ layout: default
 title: Registration
 toc: false
 ---
-[RegistrationMonitor]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AgentRegistrationMonitor
+[RegistrationMonitor]: https://docs.puppetlabs.com/mcollective/plugin_directory/agent_registration_monitor.html
 
 MCollective supports the ability for each node to register with a central inventory. The core functionality
 of Mcollective doesn't require registration internally; it's simply provided as a framework to enable you to

--- a/website/reference/plugins/rpcutil.md
+++ b/website/reference/plugins/rpcutil.md
@@ -71,7 +71,7 @@ Returns a list of all agents with their meta data like version, author, license 
 	      {:agent=>"rpcutil",
 	       :license=>"Apache License, Version 2.0",
 	       :name=>"Utilities and Helpers for SimpleRPC Agents",
-	       :url=>"http://marionette-collective.org/",
+	       :url=>"https://docs.puppetlabs.com/mcollective/",
 	       :description=> "General helpful actions that expose stats and internals to SimpleRPC clients",
 	       :version=>"1.0",
 	       :author=>"R.I.Pienaar <rip@devco.net>",

--- a/website/security.md
+++ b/website/security.md
@@ -14,8 +14,8 @@ toc: false
 [ActiveMQ SSL]: /mcollective/reference/integration/activemq_ssl.html
 [ActiveMQ STOMP]: http://activemq.apache.org/stomp.html
 [MCollective STOMP Connector]: /mcollective/reference/plugins/connector_stomp.html
-[ActionPolicy]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AuthorizationActionPolicy
-[CentralAudit]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AuditCentralRPC
+[ActionPolicy]: https://docs.puppetlabs.com/mcollective/plugin_directory/authorization_action_policy.html
+[CentralAudit]: https://docs.puppetlabs.com/mcollective/plugin_directory/central_rpc_log.html
 [Subcollectives]: reference/basic/subcollectives.html
 
 

--- a/website/simplerpc/auditing.md
+++ b/website/simplerpc/auditing.md
@@ -4,7 +4,7 @@ title: SimpleRPC Auditing
 toc: false
 ---
 [SimpleRPCIntroduction]: index.html
-[AuditCentralRPCLog]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AuditCentralRPC
+[AuditCentralRPCLog]: https://docs.puppetlabs.com/mcollective/plugin_directory/central_rpc_log.html
 
 # {{page.title}}
 

--- a/website/simplerpc/authorization.md
+++ b/website/simplerpc/authorization.md
@@ -6,7 +6,7 @@ toc: false
 [SimpleRPCIntroduction]: index.html
 [SecurityWithActiveMQ]: /mcollective/reference/integration/activemq_security.html
 [SimpleRPCAuditing]: /mcollective/simplerpc/auditing.html
-[ActionPolicy]: http://projects.puppetlabs.com/projects/mcollective-plugins/wiki/AuthorizationActionPolicy
+[ActionPolicy]: https://docs.puppetlabs.com/mcollective/plugin_directory/authorization_action_policy.html
 
 As part of the [SimpleRPC][SimpleRPCIntroduction] framework we've added an authorization system that you can use to exert fine grained control over who can call agents and actions.
 


### PR DESCRIPTION
Many links point to the projects.puppetlabs.com wiki, instead of the
migrated equivalent on docs.puppetlabs.com. Point these links to the
best places.

Also, several links point to paths on marionette-collective.org. Point
these links to docs.puppetlabs.com/mcollective.