### PR TITLE
(docs) Correct AES Security Plugin title

### DIFF
--- a/website/reference/plugins/security_aes.md
+++ b/website/reference/plugins/security_aes.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: OpenSSL based Security Plugin
+title: AES Security Plugin
 ---
 [SimpleRPCAuthorization]: /mcollective/simplerpc/authorization.html
 [Registration]: registration.html
@@ -8,6 +8,8 @@ title: OpenSSL based Security Plugin
 [SecurityOverview]: ../../security.html
 
 ## Overview
+In most cases, users will probably want to use the [SSLSecurity][] plugin instead of this one.
+
 This plugin impliments a AES encryption and RSA public / private key based security system
 for The Marionette Collective.
 
@@ -48,6 +50,9 @@ automatic key distribution.
 
 The [SSLSecurity][] plugin puts less drain on resources, if you do not specifically need encryption
 you should consider using that one instead.
+
+If you are using ActiveMQ middleware with CA-verified TLS enabled, the features of this plugin
+may not be required and you should probably use the [SSLSecurity][] plugin instead.
 
 ## Deployment Scenarios
 

--- a/website/reference/plugins/security_ssl.md
+++ b/website/reference/plugins/security_ssl.md
@@ -27,6 +27,7 @@ Validation is as default and is provided by *MCollective::Security::Base*
 Initial code was contributed by Vladimir Vuksan and modified by R.I.Pienaar
 
 An [alternative plugin][AESPlugin] exist that encrypts data but is more work to setup and maintain.
+If you are using ActiveMQ middleware with CA-verified TLS configured, this plugin is usually adequate.
 
 ## Setup
 


### PR DESCRIPTION
I noticed that both security_ssl.md and security_aes.md had the same
page title.

The aes security plugin is now filed under 'Older and
Non-Recommended Information'
https://github.com/puppetlabs/puppet-docs/blob/master/source/_includes/mcollective_menu.html#L89

As such, I've updated the AES page to more strongly suggest the use of
the SSL plugin.