### PR TITLE
Fix incorrect test for nil function return

### DIFF
--- a/lib/mcollective/matcher.rb
+++ b/lib/mcollective/matcher.rb
@@ -136,7 +136,7 @@ module MCollective
       l_compare = execute_function(function_hash)
 
       # Break out early and return false if the function returns nil
-      return false unless l_compare
+      return false unless !l_compare.nil?
 
       # Prevent unwanted discovery by limiting comparison operators
       # on Strings and Booleans


### PR DESCRIPTION
The existing code wasn't a valid test for nil.  It would prematurely exit if the function being evaluated returned false.  This meant that a test like "provision().disabled=false" would never succeed even if provision().disabled evaluated to false.

Hit this when upgrading from MCO 2.2.4 to 2.8.4.
