### PR TITLE
(maint) Update amq version to 5.11.3 for tesing

### DIFF
--- a/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
+++ b/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
@@ -1,5 +1,5 @@
 test_name 'install activemq' do
-  amq_version = '5.11.1'
+  amq_version = '5.11.3'
   # install activemq, copy config and trust/keystore
   if mco_master.platform =~ /el-|centos/ then
     install_package mco_master, 'java-1.7.0-openjdk'


### PR DESCRIPTION
amq version 5.11.1 is no longer available from apache. This
commit updates the version to the latest z release of the 5.11
amq version for installation to test against.