### PR TITLE
(MCO-742) Fix MCollective::RPC#run on Windows

### DIFF
--- a/lib/mcollective/vendor/systemu/lib/systemu.rb
+++ b/lib/mcollective/vendor/systemu/lib/systemu.rb
@@ -28,10 +28,10 @@ class SystemUniversal
 
   c = begin; ::RbConfig::CONFIG; rescue NameError; ::Config::CONFIG; end
   ruby = File.join(c['bindir'], c['ruby_install_name']) << c['EXEEXT']
-  @ruby = if system('%s -e 42' % ruby)
+  @ruby = if system(ruby, '-e', '42')
     ruby
   else
-    system('%s -e 42' % 'ruby') ? 'ruby' : warn('no ruby in PATH/CONFIG')
+    system('ruby', '-e', '42') ? 'ruby' : warn('no ruby in PATH/CONFIG')
   end
 
   class << SystemUniversal


### PR DESCRIPTION
systemu needs to be able to figure out a path to a working Ruby executable in order to work correctly. Because the systemu defaults don't reliably work as written when paths contain spaces, change the invocation of system() from single string to individual argument style invocation to clearly delineate command from argument without relying on system()'s parsing.