### PR TITLE
(MCO-744) Remove full path for systemctl in logrotate

### DIFF
--- a/ext/aio/redhat/mcollective-systemd.logrotate
+++ b/ext/aio/redhat/mcollective-systemd.logrotate
@@ -3,6 +3,6 @@
     notifempty
     sharedscripts
     postrotate
-      /usr/bin/systemctl restart mcollective >/dev/null 2>&1 || true
+      systemctl restart mcollective >/dev/null 2>&1 || true
     endscript
 }


### PR DESCRIPTION
systemctl is either in /bin or /usr/bin depending on whether or not
you're running deb-based systems. Those directories should always be in
your path so there's no need to specify the full path for systemctl.