### PR TITLE
(maint) switch to container-based travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 script: "bundle exec rake $CHECK"
 notifications:


### PR DESCRIPTION
Here we attempt to fixup the issue observed in recent travis-ci builds where
bundler is complaining that PATH contains /tmp/ (which is world-writable) by
switching to the newer container-based infrastructure.