### PR TITLE
WIP - 2.8.7 Release preparations

### DIFF
--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="2.8.6"
+  VERSION="2.8.7"
 
   def self.version
     VERSION

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -8,6 +8,9 @@ toc: false
 
 |Date|Description|Ticket|
 |----|-----------|------|
+|2016/01/13|Release *2.8.7*||
+|2015/12/17|Fix systemd logrotate unit|MCO-744|
+|2015/12/01|Fix negative data plugin comparisons|MCO-739|
 |2015/09/15|Release *2.8.6*|MCO-726|
 |2015/09/11|Fix solaris smf service manifest for aio|(#345)[https://github.com/puppetlabs/marionette-collective/pull/345]|
 |2015/09/10|Release *2.8.5*|MCO-724|

--- a/website/releasenotes.md
+++ b/website/releasenotes.md
@@ -9,6 +9,22 @@ before upgrading as any potential problems and backward incompatible changes
 will be highlighted here.
 
 
+<a name="2_8_7">&nbsp;</a>
+
+## 2.8.7 - 2016/01/13
+
+### Changes since 2.8.6
+
+* Fixed logrotate on systemd-based systems.
+* Fixed negative data plugin comparisons.
+
+
+|Date|Description|Ticket|
+|----|-----------|------|
+|2015/12/17|Fix systemd logrotate unit|MCO-744|
+|2015/12/01|Fix negative data plugin comparisons|MCO-739|
+
+
 <a name="2_8_6">&nbsp;</a>
 
 ## 2.8.6 - 2015/09/15


### PR DESCRIPTION
This is the first of two possible 2.8.7 releases (the other being #362).  

This does not incorporate the changes from #357 and just prepares the fixes currently available on master for 2.8.7.