### PR TITLE
WIP - Release 2.8.7 preparations

### DIFF
--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="2.8.6"
+  VERSION="2.8.7"
 
   def self.version
     VERSION

--- a/lib/mcollective/vendor/systemu/lib/systemu.rb
+++ b/lib/mcollective/vendor/systemu/lib/systemu.rb
@@ -28,10 +28,10 @@ class SystemUniversal
 
   c = begin; ::RbConfig::CONFIG; rescue NameError; ::Config::CONFIG; end
   ruby = File.join(c['bindir'], c['ruby_install_name']) << c['EXEEXT']
-  @ruby = if system('%s -e 42' % ruby)
+  @ruby = if system(ruby, '-e', '42')
     ruby
   else
-    system('%s -e 42' % 'ruby') ? 'ruby' : warn('no ruby in PATH/CONFIG')
+    system('ruby', '-e', '42') ? 'ruby' : warn('no ruby in PATH/CONFIG')
   end
 
   class << SystemUniversal

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -8,6 +8,10 @@ toc: false
 
 |Date|Description|Ticket|
 |----|-----------|------|
+|2016/01/13|Release *2.8.7*||
+|2015/12/17|Fix systemd logrotate unit|MCO-744|
+|2015/12/16|Fix run helper for systems where the path to ruby binary includes spaces|MCO-742|
+|2015/12/01|Fix negative data plugin comparisons|MCO-739|
 |2015/09/15|Release *2.8.6*|MCO-726|
 |2015/09/11|Fix solaris smf service manifest for aio|(#345)[https://github.com/puppetlabs/marionette-collective/pull/345]|
 |2015/09/10|Release *2.8.5*|MCO-724|

--- a/website/releasenotes.md
+++ b/website/releasenotes.md
@@ -9,6 +9,24 @@ before upgrading as any potential problems and backward incompatible changes
 will be highlighted here.
 
 
+<a name="2_8_7">&nbsp;</a>
+
+## 2.8.7 - 2016/01/13
+
+### Changes since 2.8.6
+
+* Fixed logrotate on systemd-based systems.
+* Fixed negative data plugin comparisons.
+* Fixed run helper on systems where the path to ruby includes spaces.
+
+
+|Date|Description|Ticket|
+|----|-----------|------|
+|2015/12/17|Fix systemd logrotate unit|MCO-744|
+|2015/12/16|Fix run helper for systems where the path to ruby binary includes spaces|MCO-742|
+|2015/12/01|Fix negative data plugin comparisons|MCO-739|
+
+
 <a name="2_8_6">&nbsp;</a>
 
 ## 2.8.6 - 2015/09/15


### PR DESCRIPTION
This is the second of two possible 2.8.7 releases (the first being #361)

This does incorporate the changes from #357, in addition to the other fixes currently merged.