### PR TITLE
(MCO-745) Unbreak install.rb for non-windows platforms

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -47,6 +47,8 @@ end
 
 if (defined?(RbConfig) ? RbConfig : Config)::CONFIG['host_os'] =~ /mswin|win32|dos|mingw|cygwin/i
   WINDOWS = TRUE
+else
+  WINDOWS = FALSE
 end
 
 PREREQS = %w{}


### PR DESCRIPTION
Here we define the WINDOWS constant to be FALSE on platforms that it is false
for, so we don't break there.

    install.rb:302:in `block in <main>': uninitialized constant WINDOWS (NameError)
            from /opt/puppetlabs/puppet/lib/ruby/2.1.0/fileutils.rb:125:in `chdir'
            from /opt/puppetlabs/puppet/lib/ruby/2.1.0/fileutils.rb:125:in `cd'
            from install.rb:293:in `<main>'