### PR TITLE
(MCO-748) Update mco.bat to reflect current standard

### DIFF
--- a/ext/windows/mco.bat
+++ b/ext/windows/mco.bat
@@ -1,7 +1,9 @@
 @echo off
-
 SETLOCAL
-
 call "%~dp0environment.bat" %0 %*
 
-%RUBY% -S -- mco %* --config "%CLIENT_CONFIG%"
+if [%CLIENT_CONFIG%] == [] (
+  ruby.exe -S -- mco %*
+) else (
+  ruby.exe -S -- mco %* --config "%CLIENT_CONFIG%"
+)

--- a/install.rb
+++ b/install.rb
@@ -280,7 +280,7 @@ def install_binfile(from, op_file, target)
 
   File.open(from) do |ip|
     File.open(tmp_file.path, "w") do |op|
-      op.puts "#!#{ruby}"
+      op.puts "#!#{ruby}" unless WINDOWS
       contents = ip.readlines
       contents.shift if contents[0] =~ /^#!/
       op.write contents.join


### PR DESCRIPTION
With the switch over to building puppet-agent for windows with Vanagon,
we need to effectively install mcollective with install.rb. This script
installs mco.bat, which is a wrapper that lets windows handle ruby
scripts. This commit updates mco.bat to use our environment.bat file if
we install it, and to be more in line with the mco.bat file installed
with the puppet-agent package as built by puppet_for_the_win

This takes advantage of `environment.bat` in puppet-agent installed with https://github.com/puppetlabs/puppet-agent/pull/512