### PR TITLE
(MCO-751) Manage PID files to avoid race conditions on process start

### DIFF
--- a/spec/unit/mcollective/unix_daemon_spec.rb
+++ b/spec/unit/mcollective/unix_daemon_spec.rb
@@ -13,9 +13,9 @@ module MCollective
 
       it "should write the pid file if requested", :unless => MCollective::Util.windows? do
         f = mock
-        f.expects(:write).with(Process.pid)
+        f.expects(:print).with(Process.pid)
 
-        File.expects(:open).with("/nonexisting", "w").yields(f)
+        File.expects(:open).with("/nonexisting", File::CREAT | File::EXCL | File::WRONLY).yields(f)
 
         r = mock
         r.expects(:main_loop)
@@ -23,6 +23,50 @@ module MCollective
         Runner.expects(:new).returns(r)
         UnixDaemon.expects(:daemonize).yields
 
+        UnixDaemon.daemonize_runner("/nonexisting")
+      end
+
+      it "should clean a stale pid file", :unless => MCollective::Util.windows? do
+        f = mock
+        f.expects(:print).with(Process.pid)
+
+        File.expects(:exist?).with("/nonexisting").twice.returns(true).then.returns(false)
+        File.expects(:read).with("/nonexisting").returns '1234'
+        File.expects(:unlink).with("/nonexisting")
+        Process.expects(:kill).with(0, 1234).raises(Errno::ESRCH)
+        File.expects(:open).with("/nonexisting", File::CREAT | File::EXCL | File::WRONLY).yields(f).returns true
+
+        r = mock
+        r.expects(:main_loop)
+        Runner.expects(:new).returns(r)
+        UnixDaemon.expects(:daemonize).yields
+        UnixDaemon.daemonize_runner("/nonexisting")
+      end
+
+      it "should not write a pid file if the process is running", :unless => MCollective::Util.windows? do
+        File.expects(:exist?).with("/nonexisting").returns true
+        File.expects(:read).with("/nonexisting").returns '1234'
+        Process.expects(:kill).with(0, 1234).returns true
+        File.expects(:open).never
+
+        UnixDaemon.expects(:daemonize).yields
+        expect { UnixDaemon.daemonize_runner("/nonexisting") }.to raise_error "Process is already running with PID 1234"
+      end
+
+      it "should clean an empty pid file", :unless => MCollective::Util.windows? do
+        f = mock
+        f.expects(:print).with(Process.pid)
+
+        File.expects(:exist?).with("/nonexisting").twice.returns(true).then.returns(false)
+        File.expects(:read).with("/nonexisting").returns ''
+
+        File.expects(:unlink).with("/nonexisting")
+        File.expects(:open).with("/nonexisting", File::CREAT | File::EXCL | File::WRONLY).yields(f).returns true
+
+        r = mock
+        r.expects(:main_loop)
+        Runner.expects(:new).returns(r)
+        UnixDaemon.expects(:daemonize).yields
         UnixDaemon.daemonize_runner("/nonexisting")
       end
 


### PR DESCRIPTION
The daemonize_runner was not using an exclusive create when writing its pid
file so you could get into a race condition with SysVInit by running
`service mcollective start & service mcollective start`. This also adds
checking to make sure stale PID files get cleaned up.