### PR TITLE
(MCO-634) Set build defaults to LTS targets only

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,14 +2,14 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-precise-i386.cow base-squeeze-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
+cows: 'base-precise-i386.cow base-trusty-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppetlabs'
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64'
+final_mocks: 'pl-el-6-i386 pl-el-7-x86_64'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: TRUE


### PR DESCRIPTION
We are no longer using the packaging repo to build mco packages. This
happens as a part of the puppet agent build process. This means we no
longer use the build target definitions stored in ext/build-defaults to
determine what platforms to build mco packages for. However, this is a
tool available for community use. Rather than remove these entries
entirely, we should change them to be only LTS platforms. That way, if a
community member is using this automation, they can easily edit the file
to build the platforms they want. It also helps us when we inevitably
look back at this file and wonder why we have build targets listed that
went EOL many cycles ago.