### PR TITLE
(MCO-753) The init scripts should not assume the existence of the pid dir

### DIFF
--- a/ext/aio/debian/mcollective.init
+++ b/ext/aio/debian/mcollective.init
@@ -24,7 +24,8 @@ uid=`id -u`
 
 
 # PID directory
-pidfile="/var/run/puppetlabs/mcollectived.pid"
+piddir="/var/run/puppetlabs"
+pidfile="${piddir}/mcollectived.pid"
 
 name="mcollective"
 mcollectived=/opt/puppetlabs/puppet/bin/mcollectived
@@ -52,6 +53,7 @@ fi
 case "$1" in
     start)
         echo "Starting daemon: " $name
+        mkdir -p ${piddir}
         # start the program
         start-stop-daemon --start --pidfile ${pidfile} --oknodo --quiet --startas ${mcollectived} -- ${daemonopts} --daemonize
         [ $? = 0 ] && { exit 0 ; } || { exit 1 ; }

--- a/ext/aio/redhat/mcollective.init
+++ b/ext/aio/redhat/mcollective.init
@@ -17,7 +17,9 @@
 ### END INIT INFO
 
 mcollectived="/opt/puppetlabs/puppet/bin/mcollectived"
-pidfile="/var/run/puppetlabs/mcollectived.pid"
+piddir="/var/run/puppetlabs"
+pidfile="${piddir}/mcollectived.pid"
+
 if [ -d /var/lock/subsys ]; then
     # RedHat/CentOS/etc who use subsys
     lockfile="/var/lock/subsys/mcollective"
@@ -48,6 +50,7 @@ fi
 
 start() {
     echo -n "Starting mcollective: "
+    mkdir -p ${piddir}
     # Only try to start if not already started
     if ! rh_status_q; then
       daemon ${daemonopts} ${mcollectived} --pid=${pidfile} --config="/etc/puppetlabs/mcollective/server.cfg" --daemonize

--- a/ext/aio/suse/mcollective.init
+++ b/ext/aio/suse/mcollective.init
@@ -32,7 +32,8 @@
 desc=${DESC:-mcollective daemon}
 daemon=${DAEMON:-/opt/puppetlabs/puppet/bin/mcollectived}
 name=${NAME:-mcollectived}
-pidfile=${PIDFILE:-/var/run/puppetlabs/mcollectived.pid}
+piddir=${PIDDIR:-/var/run/puppetlabs}
+pidfile=${PIDFILE:-${piddir}/mcollectived.pid}
 daemon_opts=${DAEMON_OPTS:---pid ${pidfile}}
 
 # First reset status of this service
@@ -59,6 +60,7 @@ case "$1" in
         ## the echo return value is set appropriate.
         # startproc should return 0, even if service is
         # already running to match LSB spec.
+        mkdir -p ${piddir}
         startproc -p $pidfile $daemon $daemon_opts
         # Remember status and be verbose
         rc_status -v


### PR DESCRIPTION
Currently, the init scripts naively assume that the pid directory
exists. This works well enough, assuming puppet starts first after
a reboot and creates the pid dir. This is not always the case.

This updates the init scripts to create the pid directory
if it does not exist.