### PR TITLE
(MCO-736) Singletarget

### DIFF
--- a/website/reference/plugins/connector_activemq.md
+++ b/website/reference/plugins/connector_activemq.md
@@ -311,7 +311,8 @@ The SSL ciphers to use when communicating with this middleware server.
 
 #### `plugin.activemq.agents_multiplex`
 
-Whether to use a single target for all agents in a node thus reducing the number of subscriptions in the message broker.
+Whether to use a single target for all agents in a node. This is an optimization that may make sense when running collectives with several thousands of nodes in order to reduce the number of subscriptions in the message broker.
+This is a trade-off between increasing network traffic by delivering messages to all nodes - and letting them select messages they care about - versus increasing work in the message broker to handle large numbers of subscriptions.
 
 - _Default:_ false
 - _Allowed values:_ A boolean value

--- a/website/reference/plugins/connector_activemq.md
+++ b/website/reference/plugins/connector_activemq.md
@@ -308,3 +308,11 @@ The SSL ciphers to use when communicating with this middleware server.
 
 - _Default:_ no default
 - _Allowed values:_ A string supplying an [OpenSSL cipher suite][cipherstrings]
+
+#### `plugin.activemq.agents_multiplex`
+
+Whether to use a single target for all agents in a node thus reducing the number of subscriptions in the message broker.
+
+- _Default:_ false
+- _Allowed values:_ A boolean value
+

--- a/website/reference/plugins/connector_rabbitmq.md
+++ b/website/reference/plugins/connector_rabbitmq.md
@@ -333,3 +333,11 @@ The SSL ciphers to use when communicating with the middleware.
 
 - _Default:_ no default
 - _Allowed values:_ A string supplying an [OpenSSL cipher suite][cipherstrings]
+
+#### `plugin.rabbitmq.agents_multiplex`
+
+Whether to use a single target for all agents in a node thus reducing the number of subscriptions in the message broker
+
+- _Default:_ false
+- _Allowed values:_ A boolean value
+

--- a/website/reference/plugins/connector_rabbitmq.md
+++ b/website/reference/plugins/connector_rabbitmq.md
@@ -336,7 +336,8 @@ The SSL ciphers to use when communicating with the middleware.
 
 #### `plugin.rabbitmq.agents_multiplex`
 
-Whether to use a single target for all agents in a node thus reducing the number of subscriptions in the message broker
+Whether to use a single target for all agents in a node. This is an optimization that may make sense when running collectives with several thousands of nodes in order to reduce the number of subscriptions in the message broker.
+This is a trade-off between increasing network traffic by delivering messages to all nodes - and letting them select messages they care about - versus increasing work in the message broker to handle large numbers of subscriptions.
 
 - _Default:_ false
 - _Allowed values:_ A boolean value


### PR DESCRIPTION
Implements the suggestion in MCO-736 to use a single target for all agents in the activemq connector.
We are running a collective of 6165 nodes with this change since a few weeks.
We observe that the number of subscriptions indeed dropped from ~75k to ~20k. 
The brokers are happier and querying the list of subscriptions via JMX is now faster.

```
                                      Best regards    ...Ignacio...
```
