### PR TITLE
(doc) Update installation document

### DIFF
--- a/website/deploy/install.md
+++ b/website/deploy/install.md
@@ -33,7 +33,7 @@ layout: default
 
 To install MCollective:
 
-1.  Install and start your middleware, and configure your firewalls. See the [pre-install instructions] for details.(#pre-install)
+1.  Install and start your middleware, and configure your firewalls. See the [pre-install instructions](#pre-install) for details.
 2.  Install the `mcollective` package on servers, and then make sure the `mcollective` service is running.
 3.  Install the `mcollective-client` package on admin workstations.
 
@@ -169,8 +169,8 @@ Other platforms might use different conventions.
 >     # ...
 >     libdir = /usr/libexec/mcollective
 >
-> * Good: `/usr/libexec/mcollective/mcollective/agent/discovery.rb`
-> * Bad: `/usr/libexec/mcollective/agent/discovery.rb` (This would only work if you had set a `libdir` of `/usr/libexec`.)
+> -   **Good:** `/usr/libexec/mcollective/mcollective/agent/discovery.rb`
+> -   **Bad:** `/usr/libexec/mcollective/agent/discovery.rb` (This would only work if you had set a `libdir` of `/usr/libexec`.)
 
 ### Add `mcollective/bin` to the path
 

--- a/website/deploy/install.md
+++ b/website/deploy/install.md
@@ -1,14 +1,12 @@
 ---
-title: "MCollective » Deploy » Install MCollective"
+title: "Install MCollective"
 layout: default
 ---
 
-[pe_orchestration]: /pe/latest/orchestration_overview.html
-[pe_install]: /pe/latest/install_basic.html
+[pe_orchestration]: {{pe}}/orchestration_overview.html
+[pe_install]: {{pe}}/install_basic.html
 [mco_tags]: https://github.com/puppetlabs/marionette-collective/tags
 [git_repo]: https://github.com/puppetlabs/marionette-collective
-[rakefile]: https://github.com/puppetlabs/marionette-collective/blob/master/Rakefile
-[17804]: http://projects.puppetlabs.com/issues/17804
 [server_config_best_practices]: /mcollective/configure/server.html#best-practices
 [init_lsb]: https://github.com/puppetlabs/marionette-collective/blob/master/mcollective.init
 [init_debian]: https://github.com/puppetlabs/marionette-collective/blob/master/ext/debian/mcollective.init
@@ -20,215 +18,150 @@ layout: default
 [config_server]: /mcollective/configure/server.html
 [config_client]: /mcollective/configure/client.html
 [deploy_plugins]: ./plugins.html
-[anchor_official]: #installing-with-the-official-packages
-[enable_repos]: /guides/puppetlabs_package_repositories.html
+[enable_repos]: {{puppet}}/reference/puppet_collections.html
 [server_libdir]: /mcollective/configure/server.html#platform-defaults
 [client_libdir]: /mcollective/configure/client.html#platform-defaults
 [deploy]: ./index.html
+[semver]: http://semver.org
+[puppet-agent]: {{puppet}}/references/about_agent.html
 
-Summary
------
-
-> **Note:** This page is about installing MCollective. Installation is only one step of a many-step deployment process. See the [MCollective deployment index][deploy] for the complete picture.
-
-> ### Puppet Enterprise
+> **Note:** This page is about installing MCollective, which is part of the larger deployment process. See the [MCollective deployment index][deploy] for the complete picture.
 >
-> Puppet Enterprise includes MCollective, and automates the entire deployment process. See [the PE orchestration documentation][pe_orchestration] for more details; see [the PE installation instructions][pe_install] to install PE.
+> Puppet Enterprise includes MCollective and automates the deployment process. See its [orchestration documentation][pe_orchestration] for details about using MCollective to orchestrate your Puppet Enterprise infrastructure, and its [installation instructions][pe_install] for help installing PE.
 >
-> * Puppet Enterprise 3.0 ships with MCollective 2.2.4.
-> * Puppet Enterprise 2.8 ships with MCollective 1.2.1.
+> For the versions of Puppet agent components that ship with Puppet Enterprise, including the version of MCollective, see [What Gets Installed and Where]({{pe}}/install_what_and_where.html#agent-components-on-all-nodes). For the components shipped with open source Puppet, see [About Puppet Agent][puppet-agent].
 
-Installing MCollective requires the following steps:
+To install MCollective:
 
-- [Make sure your middleware is up and running and your firewalls are in order.](#pre-install)
-- Install the `mcollective` package on servers, then make sure the `mcollective` service is running.
-- Install the `mcollective-client` package on admin workstations.
-- Most Debian-like and Red Hat-like systems can [use the official Puppet Labs packages](#installing-with-the-official-packages). Enable the Puppet Labs repos, or import the packages into your own repos.
-    - If you're on Debian/Ubuntu, [mind the missing package dependency.](#install-stomp-gem-debianubuntu)
-- If your systems can't use the official packages, [check the system requirements](#system-requirements) and either [build your own](#rolling-custom-rpm-and-deb-packages) or [run from source](#running-from-source).
+1.  Install and start your middleware, and configure your firewalls. See the [pre-install instructions] for details.(#pre-install)
+2.  Install the `mcollective` package on servers, and then make sure the `mcollective` service is running.
+3.  Install the `mcollective-client` package on admin workstations.
 
-### Best Practices
+Most Debian-like and Red Hat-like systems can [use the official `puppet-agent` package](#installing-with-the-official-packages) to install MCollective and other Puppet components and prerequisites.
+
+If your systems can't use the official package, [check the system requirements](#system-requirements) and either [build your own](#rolling-custom-rpm-and-deb-packages) or [run from source](#running-from-source).
+
+### Best practices
 
 Use site-wide configuration management software to install and configure MCollective. Since you'll need to install the server daemon on every node in your deployment, and since you'll want each node to be running the same version, you should generally use Puppet or something like it to install MCollective.
 
-### Version Notes
+### Semantic versioning
 
-MCollective uses a three-part "x.y.z" version number.
+All of our open source projects --- including Puppet, Puppet Server, PuppetDB, Facter, and Hiera --- use [semantic versioning ("semver")][semver] for their version numbers. This means that in an `x.y.z` version number, the "y" increases if new features are introduced and the "x" increases if existing features change or get removed.
 
-* The first digit doesn't have a particularly strict definition, but generally increments for major architectural breaks and incompatibilities.
-* The second digit indicates whether this is a stable release: **even** numbers are stable and production-ready, and **odd** numbers are unstable development branches in which breaking changes may happen in minor point releases.
-* The third digit reperesents the minor point release; in a stable version series, these should only contain bugfixes, and in an unstable series they may contain anything.
+Our semver promises only refer to the code in a single project; it's possible for packaging or interactions with new "y" releases of other projects to cause new behavior in a "z" upgrade of Puppet.
 
+> **Historical note:** In Puppet versions prior to 3.0.0 and Facter versions prior to 1.7.0, we didn't use semantic versioning.
 
-* * *
+## Pre-install
 
-Pre-Install
------
-
-* Your [middleware system should be deployed][middleware] before installing MCollective.
-* Make sure each server's firewall will allow MCollective to initiate connections with the middleware server. The port depends on your deployment plan; with the recommended [ActiveMQ connector][activemq_connector], this will usually be either 61614 for Stomp/TLS (recommended) or 61613 for unencrypted Stomp, depending on [how you configured ActiveMQ's transport connectors][activemq_port_config].
-
+1.  Deploy your [middleware system][middleware] before installing MCollective.
+2.  Make sure each server's firewall allows MCollective to initiate connections with the middleware server. The port depends on your deployment plan; with the recommended [ActiveMQ connector][activemq_connector], this is usually either 61614 for Stomp/TLS (recommended) or 61613 for unencrypted Stomp, depending on [how you configured ActiveMQ's transport connectors][activemq_port_config].
 
 {% capture postinstall %}[configure the server daemon][config_server], [configure admin workstations][config_client], and [deploy plugins][deploy_plugins]. See the [standard deployment getting started guide][standard] for details.{% endcapture %}
 
-
-
 ([↑ Back to top](#content))
 
-* * *
+## System requirements
 
-System Requirements
------
+MCollective can run on almost any \*nix operating system, as well as on Microsoft Windows. It requires one of the following Ruby versions:
 
-MCollective can run on almost any \*nix operating system, as well as Microsoft Windows. It requires one of the following Ruby versions:
+-   1.9.3
+-   1.8.7
 
-* 1.9.3
-* 1.8.7
+Ruby 2 is not officially supported. Ruby 1.8.5 can't use TLS when connecting to the middleware, but works fine over unencrypted connections. Ruby 1.8.6 has the same problem as 1.8.5, and somewhat less automated test coverage. Ruby 1.9.0 through 1.9.2 are NOT supported, and are expected to fail.
 
-Ruby 2 is not officially supported yet, but may work fine. Ruby 1.8.5 can't use TLS when connecting to the middleware, but works fine over unencrypted connections. Ruby 1.8.6 has the same problem as 1.8.5, and somewhat less automated test coverage. Ruby 1.9.0 through 1.9.2 are NOT supported, and are expected to fail.
+MCollective also requires version **1.2.2 or higher** of the Stomp rubygem.
 
-MCollective also requires the Stomp rubygem, version **1.2.2 or higher.** The instructions below will note when this has to be handled manually.
+## Installing with the official packages
 
-### Official Packages
+Puppet provides an official pre-built [`puppet-agent`][puppet-agent] for Windows, OS X, and the most common Linux-based operating systems. This package installs MCollective along with [Puppet]({{puppet}}), its tools, and its prerequisites.
 
-Puppet Labs provides official pre-built packages for the most common Linux-based operating systems. If you are running any of these systems, you can use the "[Official Packages][anchor_official]" install instructions.
+### Enable repositories or add packages
 
-#### Red Hat Enterprise Linux (and Derivatives)
-
-{% include platforms_redhat_like.markdown %}
-
-#### Fedora
-
-{% include platforms_fedora.markdown %}
-
-#### Debian-Like
-
-{% include platforms_debian_like.markdown %}
-
-([↑ Back to top](#content))
-
-* * *
-
-Installing With the Official Packages
------
-
-### Install Stomp Gem (Debian/Ubuntu)
-
-The current MCollective packages for Debian and Ubuntu have a missing dependency on the Stomp gem ([issue 17804][17804]). Before installing MCollective, you must install version **1.2.2 or higher** of the Stomp rubygem. Use one of the following, making sure to check the version:
-
-* The distro's `libstomp-ruby` package (older releases)
-* The distro's `ruby-stomp` package (newer releases)
-* The `stomp` gem
-
-### Enable Repos or Add Packages
-
-To use the official packages, you must first either [enable the Puppet Labs package repositories][enable_repos] on all systems, or import the following packages from our repo into your local repo:
-
-* `mcollective`
-* `mcollective-client`
-* `mcollective-common`
-* `rubygem-stomp` (on Enterprise Linux variants)
+MCollective is included in the [`puppet-agent`][puppet-agent] package. To use the official package, you must first either [enable the Puppet Collection package repositories][enable_repos] on all systems, or import the `puppet-agent` package from our repository.
 
 ### Install MCollective
 
-* On server nodes, install the `mcollective` package.
-* On admin workstations, install the `mcollective-client` package.
+Install the `puppet-agent` package using your operating system's package manager. For details, follow the [Puppet installation process]({{puppet}}/reference/install_pre.html).
 
-Both of these packages install `mcollective-common` as a dependency.
+### Enable the MCollective service
 
-### Enable the MCollective Service
+Ensure that the `mcollective` service is running and is enabled to start at boot. The `mcollective` package installs an init script that works with your system's service management tools.
 
-Ensure that the `mcollective` service is running and is enabled to start at boot. The `mcollective` package installs an init script that works with your system's normal service tools.
-
-### Done
-
-At this point, MCollective is installed and running, but cannot connect to the middleware, accept commands, or execute any actions. You should now {{ postinstall }}
+At this point, MCollective is installed and running, but can't connect to the middleware, accept commands, or execute actions. You should now {{ postinstall }}
 
 ### Example
 
-As mentioned [above](#best-practices) and [in the server config reference][server_config_best_practices], you should use Puppet or some other configuration management software to deploy MCollective on your server nodes. This can be done with a simple or modified package/file/service pattern.
+As suggested [in the best practices](#best-practices) and [server configuration reference][server_config_best_practices], use configuration management software like Puppet to deploy MCollective on your nodes. This can be done with a simple or modified package/file/service pattern.
 
-The example below uses a modified pattern. It assumes:
+The example below uses a modified pattern that assumes that you:
 
-* You are [managing settings as resources][server_config_best_practices] in a different class.
-* You are maintaining your own package repository with pre-tested versions of the MCollective packages, allowing `ensure => latest` to be used safely. All servers were deployed with this local repository enabled.
-* You are managing client workstations separately, and only automating deployment on your server nodes.
+-   [Manage settings as resources][server_config_best_practices] in a different class.
+-   Maintain your own package repository with tested versions of the MCollective packages, allowing you to safely use `ensure => latest` to automatically update packages.
+-   Deployed all servers with this local repository enabled.
+-   Manage client workstations separately, and only automate deployment on your servers.
 
-{% highlight ruby %}
-    class mcollective {
-      # Manage Stomp gem dependency on Debian/Ubuntu
-      package {'stomp':
-        ensure   => '1.2.2',
-        provider => gem,
-        before   => Package['mcollective'],
-      }
+``` ruby
+class mcollective {
+  # Install
+  package {'mcollective':
+    ensure => latest,
+  }
 
-      # Install
-      package {'mcollective':
-        ensure => latest,
-      }
-      # Run
-      service {'mcollective':
-        ensure  => running,
-        enable  => true,
-        require => Package['mcollective'],
-      }
+  # Run
+  service {'mcollective':
+    ensure  => running,
+    enable  => true,
+    require => Package['mcollective'],
+  }
 
-      # Restart the service when any settings change
-      # (see https://docs.puppetlabs.com/puppet/latest/reference/lang_collectors.html and
-      # https://docs.puppetlabs.com/puppet/latest/reference/lang_relationships.html#chaining-arrows
-      # for syntax details)
-      Package['mcollective'] -> Mcollective::Setting <| |> ~> Service['mcollective']
-    }
-{% endhighlight %}
+  # Restart the service when any settings change
+  Package['mcollective'] -> Mcollective::Setting <| |> ~> Service['mcollective']
+}
+```
+
+For details about the relationship and collector syntax used to restart the MCollective service on setting changes, see the [collector]({{puppet}}/reference/lang_collectors.html) and [chaining arrow]({{puppet}}/reference/lang_relationships.html#chaining-arrows) references.
 
 ([↑ Back to top](#content))
 
-* * *
+## Rolling custom RPM and Debian packages
 
-
-Rolling Custom RPM and Deb Packages
------
-
-If you use an RPM-based or deb-based Linux distribution not supported by the official Puppet Labs packages, you can build your own packages with the same automated tooling Puppet Labs uses.
-
-More detailed instructions on this are forthcoming; for the time being, [obtain a copy of the source][mco_tags] and do a quick read-through of the [Rakefile][]. The relevant tasks are named `deb` and `rpm`.
-
-Once you have packages, they will behave much like the official ones; follow the [same instructions above.](#installing-with-the-official-packages)
+If you use a Linux distribution that handles RPM or Debian packages but doesn't have an official `puppet-agent` package, you can build your own `puppet-agent` package. For more information, see the [puppetlabs/puppet-agent repository on GitHub](https://github.com/puppetlabs/puppet-agent).
 
 ([↑ Back to top](#content))
 
-* * *
+## Running from source
 
-Running From Source
------
+In addition to using our packages or building your own, you can also build  MCollective directly from source.
 
-On platforms not supported by the official packages or the underlying RPM and deb tooling, you can run MCollective directly from source.
+### Obtain the source
 
-### Obtain Source
+Get a copy of the MCollective source by cloning [the GitHub repo][git_repo] or [downloading a tarball][mco_tags].
 
-Get a copy of the MCollective source, either by cloning [the GitHub repo][git_repo] or [downloading a tarball][mco_tags].
+### Install Ruby and the Stomp gem
 
-### Install Ruby and the Stomp Gem
+Install Ruby, and make sure that your system's Ruby version meets [MCollective's system requirements](#system-requirements). Also, install **version 1.2.2 or higher** of the `stomp` gem.
 
-Make sure Ruby is installed and that your system's Ruby version meets [MCollective's system requirements](#system-requirements).
-
-Install **version 1.2.2 or higher** of the `stomp` rubygem.
-
-### Add `mcollective/lib` to Ruby's Load Path
+### Add `mcollective/lib` to Ruby's load path
 
 Ruby must be able to load the contents of the `lib` directory in the MCollective source. There are two main ways to do this:
 
-* Recursively copy the contents of `lib` into the `site_ruby` directory
-* Put the MCollective source somewhere like `/opt` and use the `RUBYLIB` environment variable to add it to Ruby's load path.
+-   Recursively copy the contents of `lib` into the `site_ruby` directory
+-   Put the MCollective source somewhere like `/opt` and use the `RUBYLIB` environment variable to add it to Ruby's load path.
 
-### Put `mcollective/plugins` Somewhere Sensible
+### Copy `mcollective/plugins`
 
-MCollective ships with a set of plugins it requires for basic functionality; these do not live in its normal lib path, but in an external directory specified by the `libdir` setting in MCollective's [server][server_libdir] and [client][client_libdir] config files.
+MCollective ships with a set of plugins that it requires for basic functionality. These do not live in its normal lib path, but rather in an external directory specified by the `libdir` setting in MCollective's [server][server_libdir] and [client][client_libdir] configuration files.
 
-You should copy the contents of this `plugins` directory to some platform-appropriate place; **remember the location** for your post-install configuration, since you need to specify it in the `libdir` setting. Red Hat-like platforms put plugins in `/usr/libexec/mcollective`. Debian-like platforms put it in `/usr/share/mcollective/plugins`. Your platform may have its own conventions.
+Copy the contents of this `plugins` directory to a platform-appropriate place, and **remember the location** for your post-install configuration because you need to specify it in the `libdir` setting.
 
-> **Note:** MCollective expects its `libdir` to contain a single directory named `mcollective`, which then contains the rest of the plugin directories. Be sure to not accidentally put your plugins in the directory _above_ the one MCollective will look in.
+-   Red Hat-like platforms put plugins in `/usr/libexec/mcollective`.
+-   Debian-like platforms put it in `/usr/share/mcollective/plugins`.
+
+Other platforms might use different conventions.
+
+> **Note:** MCollective expects its `libdir` to contain a single directory named `mcollective`, which then contains the rest of the plugin directories. Don't put your plugins in the _parent directory_ of the directory that MCollective checks.
 >
 > **Example:**
 >
@@ -239,35 +172,28 @@ You should copy the contents of this `plugins` directory to some platform-approp
 > * Good: `/usr/libexec/mcollective/mcollective/agent/discovery.rb`
 > * Bad: `/usr/libexec/mcollective/agent/discovery.rb` (This would only work if you had set a `libdir` of `/usr/libexec`.)
 
-### Add `mcollective/bin` to the Path
+### Add `mcollective/bin` to the path
 
-The root user on each server node must be able to execute the `mcollectived` binary. Admin users must be able to execute the `mco` binary. You should either copy these to someplace like `/usr/local/bin` and `/usr/local/sbin`, or add the directory they live in to the appropriate users' `PATH` environment variable.
+The root user on each server must be able to execute the `mcollectived` binary. Administrative users must be able to execute the `mco` binary. You should either copy these to someplace like `/usr/local/bin` and `/usr/local/sbin`, or add the directory they live in to the appropriate users' `PATH` environment variable.
 
-### Roll Your Own Init Script
+> **Note:** If you're using Puppet Enterprise, only the `peadmin` user can run the `mco` command. For more information, see the [PE MCollective actions]({{pe}}/orchestration_invoke_cli.html) documentation.
+
+### Roll your own init script
 
 There are several example init scripts in the MCollective source:
 
-* [A basic LSB-compliant init script][init_lsb]
-* [A Red Hat-like init script][init_redhat]
-* [A Debian-like init script][init_debian]
+-   [A basic LSB-compliant init script][init_lsb]
+-   [A Red Hat-like init script][init_redhat]
+-   [A Debian-like init script][init_debian]
 
-There may be other helpful files for your platform in the `mcollective/ext` directory. Use some combination of these to make a platform-appropriate init script for the MCollective server daemon.
+The `mcollective/ext` directory contains additional files that might help you install and configure the MCollective service on your platform.
 
-### Done
+At this point, MCollective is installed and running but cannot connect to the middleware, accept commands, or execute any actions. You should now {{ postinstall }}
 
-At this point, MCollective is installed and running, but cannot connect to the middleware, accept commands, or execute any actions. You should now {{ postinstall }}
+You won't be able to count on the official package's sensible defaults for MCollective's configuration files, so set the logging and `libdir` settings after installation.
 
-Unlike with the official packages, you won't be able to count on sensible defaults for the config files, so take special note of the logging settings and `libdir` setting.
+### Installing from source on Windows
 
+We currently have no instructions for installing MCollective from source on Windows. You should investigate the `ext/windows` directory in the MCollective source.
 
 ([↑ Back to top](#content))
-
-
-* * *
-
-
-Installing on Windows
------
-
-We currently have no instructions for installing MCollective on Windows. You should investigate the `ext/windows` directory in the MCollective source. If you've used MCollective on Windows, we'd love to hear about your experience, especially any unexpected pitfalls you ran into. Email <docs@puppetlabs.com>.
-


### PR DESCRIPTION
-   Update Puppet branding and puppetlabs links.
-   Resolve [MCO-384](https://tickets.puppetlabs.com/browse/MCO-384).
    -   Align semver description with Puppet's.
    -   Replace PE version information with links to the PE and OSS docs that track `puppet-agent` component versions.
    -   Remove references to resolved Stomp gem dependency issue.
-   Update case and formatting to current Puppet style guide.

CC @haus 