### PR TITLE
(doc) Update README link for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Marionette Collective aka. mcollective is a framework to build server orchestration or parallel job execution systems.
 
-For full information, wikis, ticketing and downloads please see https://puppetlabs.com/mcollective
+For documentation please see https://docs.puppet.com/mcollective
 
 ## Maintenance
 


### PR DESCRIPTION
Updates the link in the README to point to Puppet's marionette
collective docs. The prior link was inactive.

Ticketing can be found in the Maintainers section.