### PR TITLE
(maint) acceptance: allow plugin versioned install

### DIFF
--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -14,4 +14,5 @@
     'setup/aio/pre-suite/060_Install-mcollective-daemon.rb',
     'setup/aio/pre-suite/070_Install_puppet-agent-plugin.rb',
   ],
+  :plugins => [ 'mcollective-puppet-agent' ],
 }

--- a/acceptance/setup/aio/pre-suite/070_Install_puppet-agent-plugin.rb
+++ b/acceptance/setup/aio/pre-suite/070_Install_puppet-agent-plugin.rb
@@ -1,5 +1,8 @@
 test_name 'install puppet-agent plugin' do
-  hosts.each do |h|
+  require 'beaker/dsl/install_utils'
+  extend Beaker::DSL::InstallUtils
+
+  hosts.each_with_index do |h, index|
     if h.platform =~ /windows/ then
      mco_libdir = 'C:/ProgramData/PuppetLabs/mcollective/etc/plugins/mcollective'
     else
@@ -11,8 +14,43 @@ test_name 'install puppet-agent plugin' do
      install_package(h, git_pkg)
     end
     on h, "mkdir -p #{mco_libdir}"
-    on h, "git clone https://github.com/puppetlabs/mcollective-puppet-agent.git"
-    on h, "cd mcollective-puppet-agent && for i in agent aggregate application data util validator ; do cp -a $i #{mco_libdir} ; done"
+
+    SourcePath  = Beaker::DSL::InstallUtils::SourcePath
+    GitURI      = Beaker::DSL::InstallUtils::GitURI
+    GitHubSig   = Beaker::DSL::InstallUtils::GitHubSig
+
+    repositories = []
+    puppet_module_version = ENV['PUPPET_MODULE_VERSION'] || 'master'
+    options[:plugins].each do |uri|
+      raise(ArgumentError, "Missing GitURI argument. URI is nil.") if uri.nil?
+      uri += '#' + puppet_module_version if uri =~ /^mcollective-puppet-agent$/
+      project = uri.split('#')
+      fork    = project[1].split(':') if project[1]
+      if fork && fork[1]
+        newURI = "#{build_git_url(project[0],fork[0])}##{fork[1]}"
+      else
+        newURI = "#{build_git_url(project[0])}##{project[1]}"
+      end
+      raise(ArgumentError, "#{uri} is not recognized.") unless(newURI =~ GitURI)
+      repositories << extract_repo_info_from(newURI)
+    end
+
+    on h, "echo #{GitHubSig} >> $HOME/.ssh/known_hosts"
+
+    repositories.each do |repository|
+      step "Install #{repository[:name]}"
+      if repository[:path] =~ /^file:\/\/(.+)$/
+        on h, "test -d #{SourcePath} || mkdir -p #{SourcePath}"
+        source_dir = $1
+        checkout_dir = "#{SourcePath}/#{repository[:name]}"
+        on h, "rm -f #{checkout_dir}" # just the symlink, do not rm -rf !
+        on h, "ln -s #{source_dir} #{checkout_dir}"
+        on h, "cd #{checkout_dir} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi"
+      else
+        install_from_git_on h, SourcePath, repository
+      end
+      on h, "cd #{SourcePath}/#{repository[:name]} && for i in agent aggregate application data util validator ; do cp -a $i #{mco_libdir} ; done"
+    end
 
     unless h.platform =~/windows/ then
       on h, 'service mcollective restart'


### PR DESCRIPTION
Previously, the acceptance setup installed the puppet-agent plugin from
a hard-coded git repo.  This change allows different versions to be
installed from the (forked) repo.

[skip ci]