### PR TITLE
(RE-7302) Update Stomp gem dependency to >= 1.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'json'
-gem 'stomp'
+gem 'stomp', '>= 1.4.1'
 
 if RUBY_VERSION =~ /^1.8/
   gem 'systemu', '2.6.4'


### PR DESCRIPTION
The Stomp 1.4.1 gem adds fixes for SSL hostname verification