### PR TITLE
(maint) Update Ruby testing to currently supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ script: "bundle exec rake $CHECK"
 notifications:
   email: false
 rvm:
+  - 2.3.1
+  - 2.2.5
+  - 2.1.9
   - 2.0.0
   - 1.9.3
   - 1.8.7
@@ -13,6 +16,12 @@ env:
 
 matrix:
   exclude:
+    - rvm: 2.2.5
+      env: "CHECK=rubocop"
+    - rvm: 2.1.9
+      env: "CHECK=rubocop"
+    - rvm: 2.0.0
+      env: "CHECK=rubocop"
     - rvm: 1.9.3
       env: "CHECK=rubocop"
     - rvm: 1.8.7

--- a/spec/unit/mcollective/pluginmanager_spec.rb
+++ b/spec/unit/mcollective/pluginmanager_spec.rb
@@ -8,6 +8,7 @@ module MCollective
       class MCollective::Foo; end
 
       PluginManager.pluginlist.each {|p| PluginManager.delete p}
+      @config = mock
     end
 
     describe "#<<" do


### PR DESCRIPTION
2.0.0 was end-of-lifed in February, so support latest patches of all
later versions.