### PR TITLE
(MCO-775) Include discovery timeout when making requests.

### DIFF
--- a/lib/mcollective/client.rb
+++ b/lib/mcollective/client.rb
@@ -168,7 +168,10 @@ module MCollective
 
       @options = options if options
       threaded = @options[:threaded]
-      timeout = @discoverer.discovery_timeout(@options[:timeout], @options[:filter])
+      # The discovery timeout should be added to the timeout to allow global
+      # configuration in environments when nodes are slow to respond
+      dtimeout = @options[:disctimeout] || @config.discovery_timeout || 0
+      timeout = @discoverer.discovery_timeout(@options[:timeout] + dtimeout, @options[:filter])
       request = createreq(body, agent, @options[:filter])
       publish_timeout = @options[:publish_timeout]
       stat = {:starttime => Time.now.to_f, :discoverytime => 0, :blocktime => 0, :totaltime => 0}


### PR DESCRIPTION
The discovery timeout sets a base level for how long it takes agents to
respone to requests. It should be included along with any filters when
computing the discovrey timeout for all requests. Before this commit
only the --timeout or the timeout of specific agents was used. Now the
discovery timeout is added to that time to account for system wide
performance.