### PR TITLE
(MCO-776) Support PQL in STDIN discovery

### DIFF
--- a/lib/mcollective/application/find.rb
+++ b/lib/mcollective/application/find.rb
@@ -6,6 +6,8 @@ class MCollective::Application::Find<MCollective::Application
 
     starttime = Time.now
 
+    mc.detect_and_set_stdin_discovery
+
     nodes = mc.discover
 
     discoverytime = Time.now - starttime

--- a/lib/mcollective/application/rpc.rb
+++ b/lib/mcollective/application/rpc.rb
@@ -96,18 +96,8 @@ class MCollective::Application::Rpc<MCollective::Application
       puts "Request sent with id: " + mc.send(configuration[:action], configuration[:arguments])
     else
       discover_args = {:verbose => true}
-      # IF the discovery method hasn't been explicitly overridden
-      #  and we're not being run interactively,
-      #  and someone has piped us some data
-      # Then we assume it's a discovery list - this can be either:
-      #  - list of hosts in plaintext
-      #  - JSON that came from another rpc or printrpc
-      if mc.default_discovery_method && !STDIN.tty? && !STDIN.eof?
-          # Then we override discovery to try to grok the data on STDIN
-          mc.discovery_method = 'stdin'
-          mc.discovery_options = 'auto'
-          discover_args = {:verbose => false}
-      end
+
+      mc.detect_and_set_stdin_discovery
 
       mc.discover discover_args
 

--- a/lib/mcollective/discovery/stdin.rb
+++ b/lib/mcollective/discovery/stdin.rb
@@ -18,7 +18,7 @@ module MCollective
         file = STDIN.read
 
         if file =~ /^\s*$/
-              raise("data piped on STDIN contained only whitespace - could not discover hosts from it.")
+          raise("data piped on STDIN contained only whitespace - could not discover hosts from it.")
         end
 
         if type == 'auto'
@@ -29,8 +29,10 @@ module MCollective
           end
         end
 
+        Log.debug("Parsing STDIN input as type %s" % type)
+
         if type == 'json'
-          hosts = MCollective::RPC::Helpers.extract_hosts_from_json(file)
+          hosts = RPC::Helpers.extract_hosts_from_json(file)
         elsif type == 'text'
           hosts = file.split("\n")
         else

--- a/lib/mcollective/rpc/client.rb
+++ b/lib/mcollective/rpc/client.rb
@@ -119,6 +119,12 @@ module MCollective
           @stdout = STDOUT
           @stdout.sync = true
         end
+
+        if initial_options[:stdin]
+          @stdin = initial_options[:stdin]
+        else
+          @stdin = STDIN
+        end
       end
 
       # Disconnects cleanly from the middleware
@@ -457,6 +463,24 @@ module MCollective
       def reset_filter
         @filter = Util.empty_filter
         agent_filter @agent
+      end
+
+      # Detects data on STDIN and sets the STDIN discovery method
+      #
+      # IF the discovery method hasn't been explicitly overridden
+      #  and we're not being run interactively,
+      #  and someone has piped us some data
+      #
+      # Then we assume it's a discovery list - this can be either:
+      #  - list of hosts in plaintext
+      #  - JSON that came from another rpc or printrpc
+      #
+      # Then we override discovery to try to grok the data on STDIN
+      def detect_and_set_stdin_discovery
+        if self.default_discovery_method && !@stdin.tty? && !@stdin.eof?
+          self.discovery_method = 'stdin'
+          self.discovery_options = 'auto'
+        end
       end
 
       # Does discovery based on the filters set, if a discovery was

--- a/spec/unit/mcollective/rpc/helpers_spec.rb
+++ b/spec/unit/mcollective/rpc/helpers_spec.rb
@@ -33,6 +33,12 @@ module MCollective
 
           Helpers.extract_hosts_from_json(senders).should == ["sender1", "sender3"]
         end
+
+        it "should support puppet query output" do
+          senders = [{"certname" => "sender1"}, {"certname" => "sender3"}, {"certname" => "sender1"}].to_json
+
+          Helpers.extract_hosts_from_json(senders).should == ["sender1", "sender3"]
+        end
       end
 
       describe "#extract_hosts_from_array" do

--- a/website/reference/basic/basic_cli_usage.md
+++ b/website/reference/basic/basic_cli_usage.md
@@ -401,6 +401,20 @@ version of mcollective and then schedules Puppet runs on those machines:
 Mcollective results can also be filtered using the opensource gem,
 jgrep. Mcollective data output is fully compatible with jgrep.
 
+## Using with PuppetDB
+
+Recent versions of PuppetDB has a built in query language called
+Puppet Query Language that you use via the `puppet query` command.
+
+Much like the above example of chaining RPC requests MCollective supports
+reading results from Puppet Query:
+
+{% highlight console %}
+% puppet query "inventory { facts.os.name = 'CentOS' }"| mco rpc puppetd runonce
+{% endhighlight %}
+
+This will run Puppet on all CentOS machines
+
 ## Seeing the Raw Data
 
 By default the *rpc* application will try to show human-readable data.


### PR DESCRIPTION
This enables using Puppet Query output as discovery source for
mcollective

```
puppet query "inventory { facts.os.name = 'CentOS' }"| mco puppet runonce
```

Results from puppet query has to include a certname items.

This also makes the find application STDIN aware and adds a nice
reusable method to do the switch other apps can use who wish to support
this workflow
