### PR TITLE
(maint) Prepare for 2.9.1 release

### DIFF
--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="2.10.0"
+  VERSION="2.9.1"
 
   def self.version
     VERSION

--- a/website/changelog.md
+++ b/website/changelog.md
@@ -8,6 +8,7 @@ toc: false
 
 |Date|Description|Ticket|
 |----|-----------|------|
+|2016/10/24|Release *2.9.1*||
 |2016/09/23|Ping application includes discovery_timeout|MCO-775|
 |2016/08/05|Release *2.9.0*||
 |2016/06/24|Update Stomp gem dependency to >= 1.4.1|RE-7302|

--- a/website/releasenotes.md
+++ b/website/releasenotes.md
@@ -8,11 +8,25 @@ This is a list of release notes for various releases, you should review these
 before upgrading as any potential problems and backward incompatible changes
 will be highlighted here.
 
+<a name="2_9_1">&nbsp;</a>
+
+## 2.9.1 - 2016/10/24
+
+### Changes since 2.9.0
+
+* Ping application includes discovery_timeout so timeout can be increased via the config file
+
+|Date|Description|Ticket|
+|----|-----------|------|
+|2016/10/24|Release *2.9.1*||
+|2016/09/23|Ping application includes discovery_timeout|MCO-775|
+
+
 <a name="2_9_0">&nbsp;</a>
 
 ## 2.9.0 - 2016/08/05
 
-### Changes since 2.9.0
+### Changes since 2.8.9
 
 * Updated Stomp gem dependency to >= 1.4.1 for SSL-related fixes
 * Fixed mco plugins installation when using puppet-agent on Debian systems


### PR DESCRIPTION
Update the version number and changelog for 2.9.1 release.