### PR TITLE
(PA-652) Bump MCollective version to 2.9.2

### DIFF
--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="2.9.1"
+  VERSION="2.9.2"
 
   def self.version
     VERSION


### PR DESCRIPTION
This bumps the MCollective version to 2.9.2 following the release of
2.9.1 as part of puppet-agent 1.8.0.