### PR TITLE
(MCO-778) use publish_timeout from config

### DIFF
--- a/lib/mcollective/client.rb
+++ b/lib/mcollective/client.rb
@@ -170,7 +170,7 @@ module MCollective
       threaded = @options[:threaded]
       timeout = @discoverer.discovery_timeout(@options[:timeout], @options[:filter])
       request = createreq(body, agent, @options[:filter])
-      publish_timeout = @options[:publish_timeout]
+      publish_timeout = @options[:publish_timeout] || @config.publish_timeout
       stat = {:starttime => Time.now.to_f, :discoverytime => 0, :blocktime => 0, :totaltime => 0}
       STDOUT.sync = true
       hosts_responded = 0

--- a/spec/unit/mcollective/client_spec.rb
+++ b/spec/unit/mcollective/client_spec.rb
@@ -205,14 +205,25 @@ module MCollective
 
       it "should thread the publisher and receiver if configured" do
         client.instance_variable_get(:@options)[:threaded] = true
-        client.expects(:threaded_req).with(request, nil, 0, 1)
+        client.expects(:threaded_req).with(request, 2, 0, 1)
         message.options[:threaded] = true
         client.req(message)
       end
 
       it "should not thread the publisher and receiver if configured" do
         client.instance_variable_set(:@threaded, false)
-        client.expects(:unthreaded_req).with(request, nil, 0, 1)
+        client.expects(:unthreaded_req).with(request, 2, 0, 1)
+        client.req(message)
+      end
+
+      it "uses the publish_timeout from options when passed as an option" do
+        client.expects(:unthreaded_req).with(request, 5, 0, 1)
+        client.req(message, nil, message.options.merge(:publish_timeout => 5))
+      end
+
+      it "uses the publish_timeout from config when passed as a config value" do
+        client.expects(:unthreaded_req).with(request, 10, 0, 1)
+        client.instance_variable_get(:@config).expects(:publish_timeout).returns(10)
         client.req(message)
       end
     end


### PR DESCRIPTION
The Mcollective client class was previously ignoring the publish_timeout
value when specified in the config file, and by default would wait
forever when unthreaded and would crash when threaded. This commit fixes
this by preferring an explicitly set `publish_timeout` value and then
falling back to the config set value.