### PR TITLE
(MCO-777) Fix `mco ping` breakage from prior commit

### DIFF
--- a/lib/mcollective/client.rb
+++ b/lib/mcollective/client.rb
@@ -267,8 +267,10 @@ module MCollective
           end
         end
       rescue Timeout::Error => e
-        if (waitfor.is_a?(Array) && !unfinished.empty?)
-          Log.warn("Could not receive all responses. Did not receive responses from #{unfinished.keys.join(', ')}")
+        if waitfor.is_a?(Array)
+          if !unfinished.empty?
+            Log.warn("Could not receive all responses. Did not receive responses from #{unfinished.keys.join(', ')}")
+          end
         elsif (waitfor > hosts_responded)
           Log.warn("Could not receive all responses. Expected : #{waitfor}. Received : #{hosts_responded}")
         end


### PR DESCRIPTION
The prior commit for MCO-777 introduced a bug when running `mco ping`.
It would always report `The ping application failed to run: undefined
method `>' for []:Array`, as it accepts all results and then times out.
Fix by ensuring we don't attempt to compare an array to an integer.