### PR TITLE
(MCO-782) Update acceptance Rakefile

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,8 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 2.22')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.1")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.3")
 gem "rake", "~> 10.1"
 gem "httparty", :require => false
 gem 'uuidtools', :require => false

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -44,3 +44,47 @@ Commands used to set it up:
     cp ssl/private_keys/mcollective-server.pem files/server.key
     cp ssl/certs/mcollective-client.pem files/client.crt
     cp ssl/private_keys/mcollective-client.pem files/client.key
+
+# Running with Rake
+
+The rake task `ci:test:aio` will provision, install, and execute the tests
+for you. It requires the environment variable for the sha of the puppet-agent
+version that should be installed during testing.
+
+The minimal invocation of this task would be:
+```
+bundle exec rake ci:test:aio  SHA=1.8.2
+```
+
+Typically, this task would be invoked against a development build with a
+specific host target in mind. Given that we would like to test the MCO
+functionality in the latest nightly build of puppet-agent on an Ubuntu 16.04
+x86_64 instance, the command would be:
+```
+bundle exec rake ci:test:aio  SHA=nightly TEST_TARGET=ubuntu1604-64mco_master.a
+```
+
+## Environment variables
+The following environment variables are used in conjunction with the
+`ci:test:aio` rake task:
+
+SHA  _required_
+    :  Build identifier of puppet-agent version to be installed, release tag
+    or full SHA, (e.g. `nightly`, `1.8.2`,
+    `aa3068e6859a695167a4b7ac06584b4d4ace525f`).
+
+SUITE_VERSION
+    :  If the SHA used is a development build, then this variable must be
+    specified, (e.g. 1.8.2.62.gaa3068e).
+
+TEST_TARGET
+    :  Beaker-hostgenerator string used to dynamically create a Beaker hosts
+    file. The `mco_master` role must be part of this string. If left
+    unspecified, this will default to `windows2012r2-64mco_master.a`.
+
+MASTER_TEST_TARGET
+    :  Beaker-hostgenerator string used to dynamically create a Beaker hosts
+    file. If unspecified, this will default to `redhat7-64ma`.
+
+BEAKER_HOSTS
+    :  Path to an existing Beaker hosts file to be used.

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -1,6 +1,10 @@
 require 'rake/clean'
 require 'pp'
 require 'yaml'
+require 'securerandom'
+require 'fileutils'
+require 'beaker-hostgenerator'
+
 $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
 require 'puppet/acceptance/git_utils'
 extend Puppet::Acceptance::GitUtils
@@ -9,6 +13,13 @@ ONE_DAY_IN_SECS = 24 * 60 * 60
 REPO_CONFIGS_DIR = "repo-configs"
 CLEAN.include('*.tar', REPO_CONFIGS_DIR, 'merged_options.rb')
 
+# If elsewhere we're depending on internal network resources
+# then assume we can depend on them here
+EPEL_MIRROR = ENV['BEAKER_EPEL_MIRROR']
+
+# Default test target if none specified
+DEFAULT_MASTER_TEST_TARGET = 'redhat7-64m'
+DEFAULT_TEST_TARGETS = "#{DEFAULT_MASTER_TEST_TARGET}a-windows2012r2-64mco_master.a"
 module HarnessOptions
 
   DEFAULTS = {
@@ -108,7 +119,25 @@ EOS
   tests = ENV['TESTS'] || ENV['TEST']
   tests_opt = "--tests=#{tests}" if tests
 
-  config_opt = "--hosts=#{config}" if config
+  target = ENV['TEST_TARGET']
+  if config and File.exists?(config)
+    config_opt = "--hosts=#{config}"
+  else
+    if agent_target = ENV['TEST_TARGET']
+      master_target = ENV['MASTER_TEST_TARGET'] || DEFAULT_MASTER_TEST_TARGET
+      targets = "#{master_target}-#{agent_target}"
+    else
+      targets = DEFAULT_TEST_TARGETS
+    end
+    raise(USAGE) unless targets.include? 'mco_master'
+    cli = BeakerHostGenerator::CLI.new([targets, '--disable-default-role', '--osinfo-version', '1'])
+    ENV['BEAKER_HOSTS'] = "tmp/#{targets}-#{SecureRandom.uuid}.yaml"
+    FileUtils.mkdir_p('tmp')
+    File.open(config, 'w') do |fh|
+      fh.print(cli.execute)
+    end
+    config_opt = "--hosts=#{config}"
+  end
 
   overriding_options = ENV['OPTIONS']
 
@@ -242,7 +271,7 @@ def sha
 end
 
 def config
-  ENV['CONFIG']
+  ENV['BEAKER_HOSTS']
 end
 
 namespace :ci do
@@ -252,10 +281,12 @@ namespace :ci do
   end
 
   namespace :test do
-
     USAGE = <<-EOS
 Requires commit SHA to be put under test as environment variable: SHA='<sha>'.
-Also must set CONFIG=config/nodes/foo.yaml or include it in an options.rb for Beaker.
+Also must set BEAKER_HOSTS=config/nodes/foo.yaml or include it in an options.rb for Beaker,
+or specify TEST_TARGET in a form beaker-hostgenerator accepts, e.g. `ubuntu1604-64a`.
+The TEST_TARGET must include the `mco_master` role, e.g. `ubuntu1604-64mco_master.a`.
+You may override the default master test target by specifying MASTER_TEST_TARGET.
 You may set TESTS=path/to/test,and/more/tests.
 You may set additional Beaker OPTIONS='--more --options'
 If testing from git checkouts, you may optionally set the github fork to checkout from using PUPPET_FORK='some-other-puppet-fork' (you may change the HIERA_FORK and FACTER_FORK as well if you wish).

--- a/acceptance/files/client.cfg
+++ b/acceptance/files/client.cfg
@@ -12,7 +12,7 @@ plugin.ssl_client_public = /etc/puppetlabs/mcollective/client.pem
 
 connector = activemq
 plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = localhost
+plugin.activemq.pool.1.host = activemq
 plugin.activemq.pool.1.port = 61613
 plugin.activemq.pool.1.user = mcollective
 plugin.activemq.pool.1.password = marionette

--- a/acceptance/files/windows-client.cfg
+++ b/acceptance/files/windows-client.cfg
@@ -12,7 +12,7 @@ plugin.ssl_client_public = C:\ProgramData\PuppetLabs\mcollective\etc\client.pem
 
 connector = activemq
 plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = localhost
+plugin.activemq.pool.1.host = activemq
 plugin.activemq.pool.1.port = 61613
 plugin.activemq.pool.1.user = mcollective
 plugin.activemq.pool.1.password = marionette

--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -168,6 +168,37 @@ module Puppet
 
         hosts.each do |host|
           gem = Puppet::Acceptance::CommandUtils.gem_command(host)
+          gem_version = on(host, "#{gem} --version").stdout.chomp
+          if host['platform'] =~ /win/ && gem_version < '2.6.8' then
+            # The vendored gem command does not have an updated
+            # TLS cert on Windows.
+            # http://guides.rubygems.org/ssl-certificate-update
+            geotrust_ca = <<-EOS
+-----BEGIN CERTIFICATE-----
+MIIDdTCCAl2gAwIBAgILBAAAAAABFUtaw5QwDQYJKoZIhvcNAQEFBQAwVzELMAkG
+A1UEBhMCQkUxGTAXBgNVBAoTEEdsb2JhbFNpZ24gbnYtc2ExEDAOBgNVBAsTB1Jv
+b3QgQ0ExGzAZBgNVBAMTEkdsb2JhbFNpZ24gUm9vdCBDQTAeFw05ODA5MDExMjAw
+MDBaFw0yODAxMjgxMjAwMDBaMFcxCzAJBgNVBAYTAkJFMRkwFwYDVQQKExBHbG9i
+YWxTaWduIG52LXNhMRAwDgYDVQQLEwdSb290IENBMRswGQYDVQQDExJHbG9iYWxT
+aWduIFJvb3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDaDuaZ
+jc6j40+Kfvvxi4Mla+pIH/EqsLmVEQS98GPR4mdmzxzdzxtIK+6NiY6arymAZavp
+xy0Sy6scTHAHoT0KMM0VjU/43dSMUBUc71DuxC73/OlS8pF94G3VNTCOXkNz8kHp
+1Wrjsok6Vjk4bwY8iGlbKk3Fp1S4bInMm/k8yuX9ifUSPJJ4ltbcdG6TRGHRjcdG
+snUOhugZitVtbNV4FpWi6cgKOOvyJBNPc1STE4U6G7weNLWLBYy5d4ux2x8gkasJ
+U26Qzns3dLlwR5EiUWMWea6xrkEmCMgZK9FGqkjWZCrXgzT/LCrBbBlDSgeF59N8
+9iFo7+ryUp9/k5DPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8E
+BTADAQH/MB0GA1UdDgQWBBRge2YaRQ2XyolQL30EzTSo//z9SzANBgkqhkiG9w0B
+AQUFAAOCAQEA1nPnfE920I2/7LqivjTFKDK1fPxsnCwrvQmeU79rXqoRSLblCKOz
+yj1hTdNGCbM+w6DjY1Ub8rrvrTnhQ7k4o+YviiY776BQVvnGCv04zcQLcFGUl5gE
+38NflNUVyRRBnMRddWQVDf9VMOyGj/8N7yy5Y0b2qvzfvGn9LhJIZJrglfCm7ymP
+AbEVtQwdpf5pLGkkeB6zpxxxYu7KyJesF12KwvhHhm4qxFYxldBniYUr+WymXUad
+DKqC5JlR3XC321Y9YeRq4VzW9v493kHMB65jUr9TU/Qr6cf9tveCX4XSQRjbgbME
+HMUfpIBvFSDJ3gyICh3WZlXi/EjJKSZp4A==
+-----END CERTIFICATE-----
+EOS
+            p = on(host, "#{gem} which rubygems").stdout.chomp.sub('rubygems.rb', 'rubygems/ssl_certs')
+            create_remote_file(host, "#{p}/geotrustglobal.pem", geotrust_ca)
+          end
           on host, "#{gem} source --clear-all"
           on host, "#{gem} source --add #{gem_source}"
         end

--- a/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
+++ b/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
@@ -98,4 +98,11 @@ EOS
   unless port_open_within?(mco_master, 61613, 300 )
     raise Beaker::DSL::FailTest, 'Timed out trying to access ActiveMQ'
   end
+
+  step "Add activemq to hosts" do
+    ip = fact_on(mco_master, 'ipaddress')
+    hosts.each do |h|
+      apply_manifest_on(h, "host { 'activemq': ip => '#{ip}'}")
+    end
+  end
 end

--- a/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
+++ b/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
@@ -1,14 +1,15 @@
 test_name 'install activemq' do
-  amq_version = '5.11.4'
+  amq_version = '5.14.3'
+  jdk_version = '8'
   # install activemq, copy config and trust/keystore
   curl_options = '--silent --show-error --fail'
   if mco_master.platform =~ /el-|centos/ then
-    install_package mco_master, 'java-1.7.0-openjdk'
+    install_package mco_master, "java-1.#{jdk_version}.0-openjdk"
     curl_on(mco_master, "#{curl_options} -O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
     on(mco_master, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
     activemq_confdir = "/opt/apache-activemq-#{amq_version}/conf"
   elsif mco_master.platform =~/ubuntu|debian/ then
-    install_package mco_master, 'openjdk-7-jdk'
+    install_package mco_master, "openjdk-#{jdk_version}-jdk"
     curl_on(mco_master, "#{curl_options} -O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
     on(mco_master, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
     activemq_confdir = "/opt/apache-activemq-#{amq_version}/conf"
@@ -16,7 +17,7 @@ test_name 'install activemq' do
 
     step "Windows - Install Oracle JDK"
     oracle_base_url = 'https://download.oracle.com/otn-pub/java/jdk'
-    jdk_version_full = '8u45-b14'
+    jdk_version_full = '8u111-b14'
     jdk_version, jdk_build = jdk_version_full.split('-')
     if mco_master[:ruby_arch] == 'x64' then
       jdk_arch = 'x64'

--- a/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
+++ b/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
@@ -45,7 +45,7 @@ plugin.ssl_client_cert_dir = #{mco_confdir}/ssl-clients/
 
 connector = activemq
 plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = #{mco_master}
+plugin.activemq.pool.1.host = activemq
 plugin.activemq.pool.1.port = 61613
 plugin.activemq.pool.1.user = mcollective
 plugin.activemq.pool.1.password = marionette

--- a/acceptance/setup/aio/pre-suite/070_Install_puppet-agent-plugin.rb
+++ b/acceptance/setup/aio/pre-suite/070_Install_puppet-agent-plugin.rb
@@ -58,6 +58,7 @@ test_name 'install puppet-agent plugin' do
       on h, puppet('resource service mcollective ensure=stopped')
       on h, puppet('resource service mcollective ensure=running')
     end
+    sleep 30 # wait for mco to finish starting
   end
   unless port_open_within?(mco_master, 61613, 300 )
     raise Beaker::DSL::FailTest, 'Timed out trying to access ActiveMQ'


### PR DESCRIPTION
This commit updates the acceptance Rakefile to bring the
`ci:test:aio` rake task in parity with the other `puppet-agent`
components. Instructions for using this task have been added to the
`README.md` file. The task relies on a recent version of `beaker`
and `beaker-hostgenerator`.
