### PR TITLE
(MCO-783) Update mcollective log directory in the aio package

### DIFF
--- a/ext/aio/redhat/mcollective-systemd.logrotate
+++ b/ext/aio/redhat/mcollective-systemd.logrotate
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/mcollective.log {
+/var/log/puppetlabs/mcollective/mcollective.log {
     missingok
     notifempty
     sharedscripts

--- a/ext/aio/redhat/mcollective-sysv.logrotate
+++ b/ext/aio/redhat/mcollective-sysv.logrotate
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/mcollective.log {
+/var/log/puppetlabs/mcollective/mcollective.log {
     missingok
     notifempty
     sharedscripts


### PR DESCRIPTION
This is related to the proposed change in https://github.com/puppetlabs/puppet-specifications/pull/89

This updates the logrotate scripts to point to the new log location
in /var/log/puppetlabs/mcollective