### PR TITLE
(MCO-785) Fix regression in --batch option

### DIFF
--- a/acceptance/tests/mco_puppet_batch_count.rb
+++ b/acceptance/tests/mco_puppet_batch_count.rb
@@ -1,0 +1,12 @@
+test_name "mco puppet count" do
+  step "run puppet count"
+    if mco_master.platform =~ /windows/ then
+      mco_bin = 'cmd.exe /c mco.bat'
+    else
+      mco_bin = 'mco'
+    end
+    on(mco_master, "#{mco_bin} puppet count --batch=1") do
+      assert_equal(0, exit_code)
+      assert_match(/^Total Puppet nodes:\s+#{hosts.size}/, stdout)
+    end
+end

--- a/lib/mcollective/client.rb
+++ b/lib/mcollective/client.rb
@@ -284,6 +284,7 @@ module MCollective
       stat[:blocktime] = stat[:totaltime] - stat[:discoverytime]
       stat[:responses] = hosts_responded
       stat[:noresponsefrom] = []
+      stat[:unexpectedresponsefrom] = []
       stat[:requestid] = requestid
 
       @stats = stat

--- a/lib/mcollective/client.rb
+++ b/lib/mcollective/client.rb
@@ -330,6 +330,17 @@ module MCollective
 
         puts
       end
+
+      if stats[:unexpectedresponsefrom].size > 0
+        puts("\nUnexpected response from:\n")
+
+        stats[:unexpectedresponsefrom].each do |c|
+          puts if c % 4 == 1
+          printf("%30s", c)
+        end
+
+        puts
+      end
     end
   end
 end

--- a/spec/unit/mcollective/client_spec.rb
+++ b/spec/unit/mcollective/client_spec.rb
@@ -422,7 +422,8 @@ module MCollective
           :totaltime     => 10.0,
           :responses     => 5,
           :requestid     => "erfs123",
-          :noresponsefrom  => [] }
+          :noresponsefrom  => [],
+          :unexpectedresponsefrom => [] }
       end
 
       it "should update stats and return the stats hash" do

--- a/spec/unit/mcollective/rpc/client_spec.rb
+++ b/spec/unit/mcollective/rpc/client_spec.rb
@@ -774,6 +774,7 @@ module MCollective
           msg.expects(:create_reqid).returns("823a3419a0975c3facbde121f72ab61f")
           msg.expects(:requestid=).with("823a3419a0975c3facbde121f72ab61f").times(10)
 
+          # These stat keys must match the values returned by a generic Client, or `--batch` will break.
           stats = {:noresponsefrom => [], :unexpectedresponsefrom => [], :responses => 0, :blocktime => 0, :totaltime => 0, :discoverytime => 0, :requestid => "823a3419a0975c3facbde121f72ab61f"}
 
           Message.expects(:new).with('req', nil, {:type => :direct_request, :agent => 'foo', :filter => nil, :options => {}, :collective => 'mcollective'}).returns(msg).times(10)
@@ -802,6 +803,7 @@ module MCollective
           msg.expects(:create_reqid).returns("823a3419a0975c3facbde121f72ab61f")
           msg.expects(:requestid=).with("823a3419a0975c3facbde121f72ab61f").times(10)
 
+          # These stat keys must match the values returned by a generic Client, or `--batch` will break.
           stats = {:noresponsefrom => [], :unexpectedresponsefrom => [], :responses => 0, :blocktime => 0, :totaltime => 0, :discoverytime => 0, :requestid => "823a3419a0975c3facbde121f72ab61f"}
 
           Progress.expects(:new).never


### PR DESCRIPTION
It looks like changes introduced in 928ccac63ae2820bc47679264c12e4adf3ba08c6
broke --batch option, because one of stats hash elements is not
initialized as Array and concat function is called on that object which
leads to crash.

This commit will make sure, that unexpectedresponsefrom key is
initialized as Array.

P.S. I think that some unit test case is missing, as they are passing with `--batch` broken.