### PR TITLE
(maint) Add mco_master if not specified

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -129,7 +129,11 @@ EOS
     else
       targets = DEFAULT_TEST_TARGETS
     end
-    raise(USAGE) unless targets.include? 'mco_master'
+
+    if !targets.include? 'mco_master'
+      targets = targets.gsub( /([^\d]+)$/, 'mco_master.\1')
+    end
+
     cli = BeakerHostGenerator::CLI.new([targets, '--disable-default-role', '--osinfo-version', '1'])
     ENV['BEAKER_HOSTS'] = "tmp/#{targets}-#{SecureRandom.uuid}.yaml"
     FileUtils.mkdir_p('tmp')

--- a/spec/unit/mcollective/log_spec.rb
+++ b/spec/unit/mcollective/log_spec.rb
@@ -37,6 +37,7 @@ module MCollective
 
     describe "#log" do
       it "should log at the right levels" do
+        Log.configure(@logger)
         [:debug, :info, :fatal, :error, :warn].each do |level|
           @logger.expects(:log).with(level, anything, regexp_matches(/#{level} test/))
           Log.send(level, "#{level} test")


### PR DESCRIPTION
If not specified in acceptance tests, add the mco_master property to the
last agent config. Assume it's an agent-only node.

Also fixes an ordering-dependent issue in spec tests.