### PR TITLE
(MCO-786) Fix intermittent spec failures

### DIFF
--- a/spec/unit/mcollective/security/psk_spec.rb
+++ b/spec/unit/mcollective/security/psk_spec.rb
@@ -3,6 +3,11 @@
 require 'spec_helper'
 require 'mcollective/security/psk'
 
+module MCollective
+  # Clear the PluginManager so that security plugin tests do not conflict
+  PluginManager.clear
+end
+
 module MCollective::Security
   describe Psk do
     before do


### PR DESCRIPTION
When aes_security_spec was loaded before psk_spec, PluginManager would
throw a Runtimeerror that the `security_plugin` was already loaded.
Clear the plugin manager in psk_spec in case aes is loaded first.