### PR TITLE
(MCO-790) Allow M::Client users to access M::Message

### DIFF
--- a/lib/mcollective/client.rb
+++ b/lib/mcollective/client.rb
@@ -249,7 +249,13 @@ module MCollective
         Timeout.timeout(timeout) do
           loop do
             resp = receive(requestid)
-            yield resp.payload
+
+            if block.arity == 2
+              yield resp.payload, resp
+            else
+              yield resp.payload
+            end
+
             hosts_responded += 1
 
             if (waitfor.is_a?(Array))

--- a/spec/unit/mcollective/client_spec.rb
+++ b/spec/unit/mcollective/client_spec.rb
@@ -291,6 +291,22 @@ module MCollective
           results.should == ["msg1", "msg2", "msg3"]
         end
 
+        it "should support responding with the payload and the Message" do
+          results = []
+          Timeout.stubs(:timeout).yields
+
+          msg1 = mock(:payload => "msg1")
+          msg2 = mock(:payload => "msg2")
+          msg3 = mock(:payload => "msg3")
+
+          client.stubs(:receive).with("erfs123").returns(msg1, msg2, msg3)
+          client.start_receiver("erfs123", 3, 5) do |payload, message|
+            results << [payload, message]
+          end
+
+          results.should == [["msg1", msg1], ["msg2", msg2], ["msg3", msg3]]
+        end
+
         it "should log a warning if a timeout occurs" do
           results = []
           Timeout.stubs(:timeout).yields


### PR DESCRIPTION
This allow client applications that interact with the base M::Client
access to the M::Message object associated with a reply.

These clients are advanced clients such as mco ping where you'd really
would like to know things like network headers and such.

Typical end users interact with mcollective via M::RPC::Client and it's
behaviour has not changed and those users still cannot get access to
this object