### PR TITLE
(maint) Fix acceptance source for ActiveMQ

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -88,3 +88,14 @@ MASTER_TEST_TARGET
 
 BEAKER_HOSTS
     :  Path to an existing Beaker hosts file to be used.
+
+ACTIVEMQ_SOURCE
+    :  A url from which to download pre-built ActiveMQ binaries. Together with
+    ACTIVEMQ_VERSION, specifies where to get binaries. The default uses an
+    internal Puppet mirror, externally you should use http://apache.osuosl.org.
+    Note that osuosl only hosts the latest releases. Setting this will attempt
+    to fetch a package from $ACTIVEMQ_SOURCE/activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz
+    (or .zip on Windows).
+
+ACTIVEMQ_VERSION
+    :  The version of ActiveMQ requested.

--- a/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
+++ b/acceptance/setup/aio/pre-suite/050_Install-activemq.rb
@@ -1,11 +1,17 @@
 test_name 'install activemq' do
-  amq_version = '5.14.3'
+  amq_version = ENV['ACTIVEMQ_VERSION'] || '5.14.4'
+  amq_source_url = 
+    if amq_source = ENV['ACTIVEMQ_SOURCE']
+      "#{amq_source}/activemq/#{amq_version}"
+    else
+      'http://buildsources.delivery.puppetlabs.net'
+    end
   jdk_version = '8'
   # install activemq, copy config and trust/keystore
   curl_options = '--silent --show-error --fail'
   if mco_master.platform =~ /el-|centos/ then
     install_package mco_master, "java-1.#{jdk_version}.0-openjdk"
-    curl_on(mco_master, "#{curl_options} -O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
+    curl_on(mco_master, "#{curl_options} -O #{amq_source_url}/apache-activemq-#{amq_version}-bin.tar.gz")
     on(mco_master, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
     activemq_confdir = "/opt/apache-activemq-#{amq_version}/conf"
   elsif mco_master.platform =~/ubuntu|debian/ then
@@ -14,7 +20,7 @@ test_name 'install activemq' do
       jdk_version = '7'
     end
     install_package mco_master, "openjdk-#{jdk_version}-jdk"
-    curl_on(mco_master, "#{curl_options} -O http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.tar.gz")
+    curl_on(mco_master, "#{curl_options} -O #{amq_source_url}/apache-activemq-#{amq_version}-bin.tar.gz")
     on(mco_master, "cd /opt && tar xzf /root/apache-activemq-#{amq_version}-bin.tar.gz")
     activemq_confdir = "/opt/apache-activemq-#{amq_version}/conf"
   elsif mco_master.platform =~/windows/ then
@@ -60,7 +66,7 @@ EOS
 
     step "Windows - Install activemq"
     file_path = mco_master.tmpfile('activemq.zip')
-    curl_on(mco_master, "-o #{file_path}.zip http://apache.osuosl.org/activemq/#{amq_version}/apache-activemq-#{amq_version}-bin.zip")
+    curl_on(mco_master, "-o #{file_path}.zip #{amq_source_url}/apache-activemq-#{amq_version}-bin.zip")
     on(mco_master, puppet("module install reidmv-unzip"))
     manifest = <<EOS
     unzip { "activemq":


### PR DESCRIPTION
The original ActiveMQ source only hosted the latest release. Use an
internal mirror of the binaries, with an environment variable -
ACTIVEMQ_SOURCE - for overriding it.

[skip ci]