### PR TITLE
(MCO-799) Consider string and symbol keys equivelant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ rvm:
   - 2.2.5
   - 2.1.9
   - 2.0.0
-  - 1.9.3
-  - 1.8.7
 env:
   - "CHECK=test"
   - "CHECK=rubocop"
@@ -21,8 +19,4 @@ matrix:
     - rvm: 2.1.9
       env: "CHECK=rubocop"
     - rvm: 2.0.0
-      env: "CHECK=rubocop"
-    - rvm: 1.9.3
-      env: "CHECK=rubocop"
-    - rvm: 1.8.7
       env: "CHECK=rubocop"

--- a/lib/mcollective/ddl/agentddl.rb
+++ b/lib/mcollective/ddl/agentddl.rb
@@ -183,7 +183,7 @@ module MCollective
       #
       # This is to assist with moving to a JSON pure world where requests might come
       # in from REST or other languages, those languages and indeed JSON itself does
-      # support symbols.
+      # not support symbols.
       #
       # It ensures a backward compatible mode where for rpcutil both of these requests
       # are equivelant

--- a/lib/mcollective/rpc/client.rb
+++ b/lib/mcollective/rpc/client.rb
@@ -739,8 +739,13 @@ module MCollective
       end
 
       def rpc_result_from_reply(agent, action, reply)
-        Result.new(agent, action, {:sender => reply[:senderid], :statuscode => reply[:body][:statuscode],
-                                   :statusmsg => reply[:body][:statusmsg], :data => reply[:body][:data]})
+        senderid = reply.include?("senderid") ? reply["senderid"] : reply[:senderid]
+        body = reply.include?("body") ? reply["body"] : reply[:body]
+        s_code = body.include?("statuscode") ? body["statuscode"] : body[:statuscode]
+        s_msg = body.include?("statusmsg") ? body["statusmsg"] : body[:statusmsg]
+        data = body.include?("data") ? body["data"] : body[:data]
+
+        Result.new(agent, action, {:sender => senderid, :statuscode => s_code, :statusmsg => s_msg, :data => data})
       end
 
       # for requests that do not care for results just

--- a/lib/mcollective/rpc/helpers.rb
+++ b/lib/mcollective/rpc/helpers.rb
@@ -231,7 +231,6 @@ module MCollective
           result_text << ""
         else
           [result].flatten.each do |r|
-
             if flags[:verbose]
               result_text << "%-40s: %s\n" % [r[:sender], r[:statusmsg]]
 

--- a/lib/mcollective/rpc/request.rb
+++ b/lib/mcollective/rpc/request.rb
@@ -6,45 +6,69 @@ module MCollective
 
       def initialize(msg, ddl)
         @time = msg[:msgtime]
-        @action = msg[:body][:action]
-        @data = msg[:body][:data]
+        @action = msg[:body][:action] || msg[:body]["action"]
+        @data = msg[:body][:data] || msg[:body]["data"]
         @sender = msg[:senderid]
-        @agent = msg[:body][:agent]
+        @agent = msg[:body][:agent] || msg[:body]["agent"]
         @uniqid = msg[:requestid]
         @caller = msg[:callerid] || "unknown"
         @ddl = ddl
+      end
+
+      # In a scenario where a request came from a JSON pure medium like a REST
+      # service or other language client DDL::AgentDDL#validate_rpc_request will
+      # check "package" against the intput :package should the input "package" not
+      # also be known
+      #
+      # Thus once the request is built it will also have "package" and not :package
+      # data, so we need to fetch the correct key out of the hash.
+      def compatible_key(key)
+        return key if data.include?(key)
+
+        if ddl
+          input = ddl.action_interface(action)[:input]
+
+          # if :package is requested and the DDL also declares "package" we cant tell it to fetch
+          # "package", hence the check against the input here
+          return key.to_s if key.is_a?(Symbol) && !input.include?(key.to_s) && data.include?(key.to_s)
+        end
+
+        key
       end
 
       # If data is a hash, quick helper to get access to it's include? method
       # else returns false
       def include?(key)
         return false unless @data.is_a?(Hash)
-        return @data.include?(key)
+
+        @data.include?(compatible_key(key))
       end
 
       # If no :process_results is specified always respond else respond
       # based on the supplied property
       def should_respond?
+        return false unless @data.is_a?(Hash)
         return @data[:process_results] if @data.include?(:process_results)
+        return @data["process_results"] if @data.include?("process_results")
 
-        return true
+        true
       end
 
       # If data is a hash, gives easy access to its members, else returns nil
       def [](key)
         return nil unless @data.is_a?(Hash)
-        return @data[key]
+        return @data[compatible_key(key)]
       end
 
       def fetch(key, default)
         return nil unless @data.is_a?(Hash)
-        return @data.fetch(key, default)
+        return @data.fetch(compatible_key(key), default)
       end
 
       def to_hash
-        return {:agent => @agent,
-                :action => @action,
-                :data => @data}
+        {:agent => @agent,
+         :action => @action,
+         :data => @data}
       end
 
       # Validate the request against the DDL

--- a/lib/mcollective/rpc/result.rb
+++ b/lib/mcollective/rpc/result.rb
@@ -14,18 +14,59 @@ module MCollective
         @agent = agent
         @action = action
         @results = result
+
+        convert_data_based_on_ddl if ddl
       end
 
-      def [](idx)
-        @results[idx]
+      def ddl
+        @_ddl ||= DDL.new(agent)
+      rescue
+        nil
       end
 
-      def []=(idx, item)
-        @results[idx] = item
+      def data
+        @results[:data] = @results.delete("data") if @results.include?("data")
+
+        self[:data]
+      end
+
+      # Converts keys on the supplied data to those listed as outputs
+      # in the DDL.  This is to facilitate JSON based transports
+      # without forcing everyone to rewrite DDLs and clients to
+      # convert symbols to strings, the data will be on symbol keys
+      # if the DDL has a symbol and not a string output defined
+      def convert_data_based_on_ddl
+        interface = ddl.action_interface(action)
+
+        return if interface.fetch(:output, {}).empty?
+
+        interface[:output].each do |output, properties|
+          next if data.include?(output)
+
+          if output.is_a?(Symbol) && data.include?(output.to_s)
+            data[output] = data.delete(output.to_s)
+          end
+        end
+      end
+
+      def compatible_key(key)
+        if key.is_a?(Symbol) && @results.include?(key.to_s)
+          key.to_s
+        else
+          key
+        end
+      end
+
+      def [](key)
+        @results[compatible_key(key)]
+      end
+
+      def []=(key, item)
+        @results[key] = item
       end
 
       def fetch(key, default)
-        @results.fetch(key, default)
+        @results.fetch(compatible_key(key), default)
       end
 
       def each
@@ -35,10 +76,10 @@ module MCollective
       def to_json(*a)
         {:agent => @agent,
          :action => @action,
-         :sender => @results[:sender],
-         :statuscode => @results[:statuscode],
-         :statusmsg => @results[:statusmsg],
-         :data => @results[:data]}.to_json(*a)
+         :sender => self[:sender],
+         :statuscode => self[:statuscode],
+         :statusmsg => self[:statusmsg],
+         :data => data}.to_json(*a)
       end
 
       def <=>(other)

--- a/spec/unit/mcollective/rpc/client_spec.rb
+++ b/spec/unit/mcollective/rpc/client_spec.rb
@@ -39,6 +39,65 @@ module MCollective
         @client.stubs(:ddl).returns(ddl)
       end
 
+      describe "#rpc_result_from_reply" do
+        it "should support symbol style replies" do
+          raw_result = {
+            :senderid => "rspec.id",
+            :body => {
+              :statuscode => 1,
+              :statusmsg => "rspec status",
+              :data => {
+                :one => 1
+              }
+            }
+          }
+
+          result = @client.rpc_result_from_reply("rspec", "test", raw_result)
+
+          expect(result.agent).to eq("rspec")
+          expect(result.action).to eq("test")
+          expect(result[:sender]).to eq("rspec.id")
+          expect(result[:statuscode]).to eq(1)
+          expect(result[:statusmsg]).to eq("rspec status")
+          expect(result[:data]).to eq(:one => 1)
+          expect(result.results).to eq(
+            :sender => "rspec.id",
+            :statuscode => 1,
+            :statusmsg => "rspec status",
+            :data => {:one => 1}
+          )
+        end
+
+        it "should support string style replies" do
+          raw_result = {
+            "senderid" => "rspec.id",
+            "body" => {
+              "statuscode" => 1,
+              "statusmsg" => "rspec status",
+              "data" => {
+                "one" => 1,
+                "two" => 2
+              }
+            }
+          }
+
+          result = @client.rpc_result_from_reply("rspec", "test", raw_result)
+
+          expect(result.agent).to eq("rspec")
+          expect(result.action).to eq("test")
+          expect(result[:sender]).to eq("rspec.id")
+          expect(result[:statuscode]).to eq(1)
+          expect(result[:statusmsg]).to eq("rspec status")
+          expect(result[:data]).to eq("one" => 1, "two" => 2)
+          expect(result.results).to eq(
+            :sender => "rspec.id",
+            :statuscode => 1,
+            :statusmsg => "rspec status",
+            :data => {"one" => 1, "two" => 2}
+          )
+        end
+      end
+
       describe "#detect_and_set_stdin_discovery" do
         before(:each) do
           @client = Client.new("foo", {:options => {:filter => Util.empty_filter, :config => "/nonexisting", :stdin => @stdin}})

--- a/spec/unit/mcollective/rpc/result_spec.rb
+++ b/spec/unit/mcollective/rpc/result_spec.rb
@@ -27,6 +27,34 @@ module MCollective
         end
       end
 
+      describe "#convert_data_based_on_ddl" do
+        it "should convert string data to symbol data based on the DDL" do
+          ddl = DDL.new("rspec", :agent, false)
+          ddl.metadata(:name => "name", :description => "description", :author => "author", :license => "license", :version => "version", :url => "url", :timeout => "timeout")
+          ddl.action("test", :description => "rspec")
+          ddl.instance_variable_set("@current_entity", "test")
+          ddl.output(:one, :description => "rspec one", :display_as => "One")
+
+          DDL.expects(:new).with("rspec").returns(ddl)
+
+          raw_result = {
+            "sender" => "rspec.id",
+            "statuscode" => 1,
+            "statusmsg" => "rspec status",
+            "data" => {
+              "one" => 1,
+              "two" => 2
+            }
+          }
+
+          result = Result.new("rspec", "test", raw_result)
+          expect(result.data).to eq(
+            :one => 1,
+            "two" => 2
+          )
+        end
+      end
+
       describe "#[]" do
         it "should access the results hash and return correct data" do
           @result[:foo].should == "bar"
@@ -71,17 +99,17 @@ module MCollective
 
       describe "#<=>" do
         it "should implement the Combined Comparison operator based on sender name" do
-          result_a = Result.new("tester", 
-                                "test", 
-                                { :statuscode => 0, 
-                                  :statusmsg => "OK", 
-                                  :sender => "a_rspec",  
+          result_a = Result.new("tester",
+                                "test",
+                                { :statuscode => 0,
+                                  :statusmsg => "OK",
+                                  :sender => "a_rspec",
                                   :data => {}})
-          result_b = Result.new("tester", 
-                                "test", 
-                                { :statuscode => 0, 
-                                  :statusmsg => "OK", 
-                                  :sender => "b_rspec",  
+          result_b = Result.new("tester",
+                                "test",
+                                { :statuscode => 0,
+                                  :statusmsg => "OK",
+                                  :sender => "b_rspec",
                                   :data => {}})
 
           (result_a <=> result_b).should == -1


### PR DESCRIPTION
This has the end effect that:

    c.get_fact(:fact => "cluster")

is the same as:

    c.get_fact("fact" => "cluster")

in the case where the DDL defined the input :fact for the action
:get_fact

Additionally RPC::Request will now intelligently convert request[:foo]
into fetching "foo" from such a request.  We could perhaps munge the
entire incoming request instead of this approach but this seems simpler
to implement

Long term I want to downgrade MCollective network protocols to be JSON
pure to facilitate non Ruby clients and JSON based REST gateways and
just general removal of user supplied YAML.

This changes makes it so that not everyone have to redevelop their DDLs,
Agents and Clients

The one problem case is where someone legit made a input :foo and also
one "foo" on the same action, if all we have is a string to represent
the input - "foo" - we cannot distinguish between them, such agents will
now warn on the client.  I anticipate this to be extreme edge cases as
we've been really good at recommending symbols in all docs and all our
agents