### PR TITLE
(MCO-783) Update mcollective log directory in the aio package

### DIFF
--- a/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
+++ b/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
@@ -28,7 +28,7 @@ test_name 'configure mcollective daemon' do
 main_collective = mcollective
 collectives = mcollective
 libdir = #{libdir}
-logfile = #{logdir}/mcollective.log
+logfile = #{logdir}/mcollective/mcollective.log
 loglevel = info
 daemonize = 1
 

--- a/ext/aio/common/server.cfg.dist
+++ b/ext/aio/common/server.cfg.dist
@@ -7,7 +7,7 @@ libdir = /opt/puppetlabs/mcollective/plugins
 libdir = /usr/share/mcollective/plugins
 libdir = /usr/libexec/mcollective
 
-logfile = /var/log/puppetlabs/mcollective.log
+logfile = /var/log/puppetlabs/mcollective/mcollective.log
 loglevel = info
 daemonize = 1
 

--- a/ext/aio/redhat/mcollective-systemd.logrotate
+++ b/ext/aio/redhat/mcollective-systemd.logrotate
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/mcollective.log {
+/var/log/puppetlabs/mcollective/mcollective.log {
     missingok
     notifempty
     sharedscripts

--- a/ext/aio/redhat/mcollective-sysv.logrotate
+++ b/ext/aio/redhat/mcollective-sysv.logrotate
@@ -1,4 +1,4 @@
-/var/log/puppetlabs/mcollective.log {
+/var/log/puppetlabs/mcollective/mcollective.log {
     missingok
     notifempty
     sharedscripts

--- a/lib/mcollective/audit/logfile.rb
+++ b/lib/mcollective/audit/logfile.rb
@@ -10,7 +10,7 @@ module MCollective
       require 'pp'
 
       def audit_request(request, connection)
-        logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/mcollective-audit.log"
+        logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/puppetlabs/mcollective/mcollective-audit.log"
 
         now = Time.now
         # Already told timezone to be in UTC so we don't look it up again

--- a/spec/unit/mcollective/audit/logfile_spec.rb
+++ b/spec/unit/mcollective/audit/logfile_spec.rb
@@ -36,7 +36,7 @@ module MCollective
 
       it 'should log to a default logfile' do
         Config.any_instance.stubs(:pluginconf).returns({})
-        File.expects(:open).with("/var/log/mcollective-audit.log", "a").yields(file)
+        File.expects(:open).with("/var/log/puppetlabs/mcollective/mcollective-audit.log", "a").yields(file)
         Logfile.new.audit_request(request, nil)
       end
     end

--- a/website/deploy/standard.md
+++ b/website/deploy/standard.md
@@ -345,7 +345,7 @@ This example template snippet shows the settings you need to use in a standard d
     # Logging:
     logger_type = file
     loglevel = info
-    logfile = /var/log/puppetlabs/mcollective.log
+    logfile = /var/log/puppetlabs/mcollective/mcollective.log
     keeplogs = 5
     max_log_size = 2097152
     logfacility = user

--- a/website/simplerpc/auditing.md
+++ b/website/simplerpc/auditing.md
@@ -35,7 +35,7 @@ module MCollective
 	    require 'pp'
 
             def audit_request(request, connection)
-                logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/mcollective-audit.log"
+                logfile = Config.instance.pluginconf["rpcaudit.logfile"] || "/var/log/puppetlabs/mcollective/mcollective-audit.log"
 
                 now = Time.now
                 now_tz = tz = now.utc? ? "Z" : now.strftime("%z")
@@ -55,7 +55,7 @@ As you can see you only need to provide one method called _audit_request_, you w
 The Logfile plugin takes a configuration option:
 
 {% highlight ini %}
-plugin.rpcaudit.logfile = /var/log/mcollective-audit.log
+plugin.rpcaudit.logfile = /var/log/puppetlabs/mcollective/mcollective-audit.log
 {% endhighlight %}
 
 We do not do log rotation of this file so you should do that yourself if you enable this plugin.


### PR DESCRIPTION
This is related to the proposed change in https://github.com/puppetlabs/puppet-specifications/pull/89

This updates the log configuration and logrotate scripts to point to the
new log location in /var/log/puppetlabs/mcollective

Replaces https://github.com/puppetlabs/marionette-collective/pull/410.