### PR TITLE
(MCO-804) Skip cipher monkey patch on ruby 2.4+

### DIFF
--- a/lib/mcollective/monkey_patches.rb
+++ b/lib/mcollective/monkey_patches.rb
@@ -134,7 +134,9 @@ class OpenSSL::SSL::SSLContext
     DEFAULT_PARAMS[:options] |= OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS
   end
 
-  DEFAULT_PARAMS[:ciphers] << ':!SSLv2'
+  if DEFAULT_PARAMS[:ciphers]
+    DEFAULT_PARAMS[:ciphers] << ':!SSLv2'
+  end
 
   alias __mcollective_original_initialize initialize
   private :__mcollective_original_initialize


### PR DESCRIPTION
ly, we appended "!SSLv2" to the SSLContext
DEFAULT_PARAMS[:ciphers] to ensure that mcollective never uses SSLv2,
either from our http client or when using open-uri. However, ruby 2.4
only defines the `:ciphers` array if using openssl < 1.1.0[1]. As a
result, mcollective running on newer systems would hard fail.

Check existence of array before trying to append to it.

[1] ruby/ruby@c9dc016#diff-8406e11e4a42f9de6badcd0f6a6c4262R33