### PR TITLE
(MCO-783) Correct Windows log location

### DIFF
--- a/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
+++ b/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
@@ -14,7 +14,7 @@ test_name 'configure mcollective daemon' do
     unless h.platform =~/windows/ then
       mco_confdir = "/etc/puppetlabs/mcollective"
       libdir = "/opt/puppetlabs/mcollective/plugins"
-      logdir = "/var/log/puppetlabs"
+      logdir = "/var/log/puppetlabs/mcollective"
       puppet_confdir = "/etc/puppetlabs/puppet"
     else
       mco_confdir = "C:/ProgramData/PuppetLabs/mcollective/etc"
@@ -28,7 +28,7 @@ test_name 'configure mcollective daemon' do
 main_collective = mcollective
 collectives = mcollective
 libdir = #{libdir}
-logfile = #{logdir}/mcollective/mcollective.log
+logfile = #{logdir}/mcollective.log
 loglevel = info
 daemonize = 1
 


### PR DESCRIPTION
The prior commit for MCO-783 moved the Windows log location as well,
which was not intended. Fix so only the *nix location is modified in
testing.