### PR TITLE
(maint) Add test for PA-1168

### DIFF
--- a/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
+++ b/acceptance/setup/aio/pre-suite/060_Install-mcollective-daemon.rb
@@ -38,6 +38,8 @@ plugin.ssl_server_public = #{mco_confdir}/server.crt
 plugin.ssl_client_cert_dir = #{mco_confdir}/ssl-clients/
 
 connector = activemq
+plugin.activemq.heartbeat_interval = 30
+plugin.activemq.max_hbrlck_fails = 2
 plugin.activemq.pool.size = 1
 plugin.activemq.pool.1.host = activemq
 plugin.activemq.pool.1.port = 61613

--- a/acceptance/tests/mco_reconnect.rb
+++ b/acceptance/tests/mco_reconnect.rb
@@ -1,0 +1,36 @@
+test_name "mco servers should reconnect if cut-off from broker" do
+  skip_test "Can't manipulate firewall rules easily on Windows" if mco_master.platform =~ /windows/
+
+  # Add firewall rules blocking the source ports for the current incoming connections.
+  # When nodes attempt to reconnect, they'll grab a new outgoing port and should bypass the firewall rules.
+  step "disconnect servers" do
+    hosts.reject {|host| host == mco_master}.each do |host|
+      ip = fact_on(host, 'ipaddress')
+      mco_port = on(mco_master, "netstat -anpt|grep 61613|grep ESTAB|grep -Po '#{ip}:\\K\\d+'").stdout.chomp
+      step "blocking traffic to #{ip}:#{mco_port}" do
+        on(mco_master, "iptables -A INPUT -p tcp --sport #{mco_port} -j DROP")
+        on(mco_master, "iptables -A OUTPUT -p tcp --dport #{mco_port} -j DROP")
+      end
+    end
+
+    on(mco_master, 'iptables -L')
+    teardown do
+      on(mco_master, 'iptables -F')
+    end
+  end
+
+  step "check unreachable ping" do
+    on(mco_master, "mco ping") do
+      assert_equal(0, exit_code)
+      assert_match(/^1\s+replies/, stdout)
+    end
+  end
+
+  # It takes 2 heartbeat failures before stomp will retry. The minimum configurable heartbeat is 30 seconds,
+  # so 30 is the minimum time before mcollective could reconnect.
+  sleep 30
+
+  step "check for reconnection" do
+    retry_on(mco_master, "mco ping | grep '#{hosts.size} replies'", {:max_retries => 10, :retry_interval => 5})
+  end
+end


### PR DESCRIPTION
Adds a test ensuring mcollective servers will reconnect to ActiveMQ
after a hard connection loss. Simulates lost connections by blocking
ports via the firewall.

Depends on https://github.com/puppetlabs/puppet-agent/pull/1071.