### PR TITLE
(maint) Fix the test on win-10-ent-i386

### DIFF
--- a/acceptance/tests/mco_puppet_exec.rb
+++ b/acceptance/tests/mco_puppet_exec.rb
@@ -23,7 +23,7 @@ test_name "mco puppet exec" do
           content => '
             node default {
               exec { "hostname":
-                path => ["/bin", "/usr/bin", "C:/cygwin32/bin", "C:/cygwin64/bin"],
+                path => ["/bin", "/usr/bin", "C:/cygwin32/bin", "C:/cygwin64/bin", "C:/cygwin/bin"],
                 logoutput => true,
               }
             }


### PR DESCRIPTION
Cygwin is installed at C:/cygwin, not C:/cygwin32.

[skip ci]