### PR TITLE
(MCO-815) Correctly determine reply status in all modes

### DIFF
--- a/lib/mcollective/rpc/client.rb
+++ b/lib/mcollective/rpc/client.rb
@@ -1000,9 +1000,9 @@ module MCollective
         result = rpc_result_from_reply(@agent, action, resp)
         aggregate = aggregate_reply(result, aggregate) if aggregate
 
-        if resp[:body][:statuscode] == 0 || resp[:body][:statuscode] == 1
-          @stats.ok if resp[:body][:statuscode] == 0
-          @stats.fail if resp[:body][:statuscode] == 1
+        if result[:statuscode] == 0 || result[:statuscode] == 1
+          @stats.ok if result[:statuscode] == 0
+          @stats.fail if result[:statuscode] == 1
         else
           @stats.fail
         end
@@ -1020,8 +1020,8 @@ module MCollective
         result = rpc_result_from_reply(@agent, action, resp)
         aggregate = aggregate_reply(result, aggregate) if aggregate
 
-        @stats.ok if resp[:body][:statuscode] == 0
-        @stats.fail if resp[:body][:statuscode] != 0
+        @stats.ok if result[:statuscode] == 0
+        @stats.fail if result[:statuscode] != 0
         @stats.time_block_execution :start
 
         case block.arity

--- a/spec/unit/mcollective/rpc/client_spec.rb
+++ b/spec/unit/mcollective/rpc/client_spec.rb
@@ -175,7 +175,6 @@ module MCollective
         it "should inform the stats object correctly for passed requests" do
           response = {:senderid => "rspec", :body => {:statuscode => 0}}
 
-          @client.stubs(:rpc_result_from_reply).with("foo", "rspec", response)
           @client.stats.expects(:ok)
           @client.stats.expects(:node_responded).with("rspec")
           @client.stats.expects(:time_block_execution).with(:start)
@@ -194,7 +193,6 @@ module MCollective
           response = {:senderid => "rspec", :body => {:statuscode => 1}}
           blk = Proc.new {}
 
-          @client.stubs(:rpc_result_from_reply).with("foo", "rspec", response)
           @client.process_results_with_block("rspec", response, blk, nil)
         end
 
@@ -202,7 +200,6 @@ module MCollective
           response = {:senderid => "rspec", :body => {:statuscode => 1}}
           blk = Proc.new {|r| r.should == response}
 
-          @client.stubs(:rpc_result_from_reply).with("foo", "rspec", response)
           @client.process_results_with_block("rspec", response, blk, nil)
         end
 
@@ -220,7 +217,6 @@ module MCollective
       describe "#process_results_without_block" do
         it "should inform the stats object correctly for passed requests" do
           response = {:senderid => "rspec", :body => {:statuscode => 0}}
-          @client.stubs(:rpc_result_from_reply).with("foo", "rspec", response)
           @client.stats.expects(:ok)
           @client.stats.expects(:node_responded).with("rspec")
           @client.process_results_without_block(response, "rspec", nil)
@@ -231,11 +227,9 @@ module MCollective
           @client.stats.expects(:node_responded).with("rspec").twice
 
           response = {:senderid => "rspec", :body => {:statuscode => 1}}
-          @client.stubs(:rpc_result_from_reply).with("foo", "rspec", response)
           @client.process_results_without_block(response, "rspec", nil)
 
           response = {:senderid => "rspec", :body => {:statuscode => 3}}
-          @client.stubs(:rpc_result_from_reply).with("foo", "rspec", response)
           @client.process_results_without_block(response, "rspec", nil)
         end
 


### PR DESCRIPTION
When JSON serializers are enabled the result needs to be processed by
the rpc_result_from_reply method to be processed into the right format
based on the DDL

The methods that determined the reply status though acted on the
unconverted raw data and so would incorrectly determine the reply failed
when it did not