### PR TITLE
(MCO-816) Allow upgrading puppet-agent with mcollective

### DIFF
--- a/ext/aio/redhat/mcollective.service
+++ b/ext/aio/redhat/mcollective.service
@@ -19,6 +19,7 @@ StandardError=syslog
 ExecStart=/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --pidfile=/var/run/puppetlabs/mcollective.pid --daemonize
 ExecReload=/bin/kill -USR1 $MAINPID
 PIDFile=/var/run/puppetlabs/mcollective.pid
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/ext/redhat/mcollective.service
+++ b/ext/redhat/mcollective.service
@@ -19,6 +19,7 @@ StandardError=syslog
 ExecStart=/usr/sbin/mcollectived --config=/etc/mcollective/server.cfg --pidfile=/var/run/mcollective.pid --no-daemonize
 ExecReload=/bin/kill -USR1 $MAINPID
 PIDFile=/var/run/mcollective.pid
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since mcollective is part of puppet-agent packaging, upgrading that
package over an mcollective plugin is tricky. Previously the mcollective
systemd service was currently configured in a way that broke that,
because it killed the entire process tree when stopping as part of the
upgrade.

Set `KillMode=process` for the systemd service (similar to how Puppet
and PXP Agent are configured) so that it can be restarted during the
upgrade without killing the upgrade itself.