### PR TITLE
(MCO-817) Allow unquoted function arguments

### DIFF
--- a/lib/mcollective/matcher/scanner.rb
+++ b/lib/mcollective/matcher/scanner.rb
@@ -188,8 +188,9 @@ module MCollective
           return "bad_token", [@token_index - current_token_value.size + 1, @token_index]
         else
           if func
-            if current_token_value.match(/^.+?\((\s*(')[^']*(')\s*(,\s*(')[^']*('))*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/) ||
-               current_token_value.match(/^.+?\((\s*(")[^"]*(")\s*(,\s*(")[^"]*("))*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/)
+            if current_token_value.match(/^.+?\((\s*'[^']*'\s*(,\s*'[^']*')*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/) ||
+               current_token_value.match(/^.+?\((\s*"[^"]*"\s*(,\s*"[^"]*")*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/) ||
+               current_token_value.match(/^.+?\((\s*[^'"]*\s*(,\s*[^'"]*)*)?\)(\.[a-zA-Z0-9_]+)?((!=|<=|>=|=|>|<).+)?$/)
               return "fstatement", current_token_value
             else
               return "bad_token", [@token_index - current_token_value.size + 1, @token_index]

--- a/spec/unit/mcollective/matcher/scanner_spec.rb
+++ b/spec/unit/mcollective/matcher/scanner_spec.rb
@@ -71,6 +71,18 @@ module MCollective
         token.should == ["fstatement", "foo('bar')"]
       end
 
+      it "should identify a function statement token with double quotes" do
+        scanner = Scanner.new('foo("bar")')
+        token = scanner.get_token
+        token.should == ["fstatement", 'foo("bar")']
+      end
+
+      it "should identify a function statement token with no quotes" do
+        scanner = Scanner.new("foo(bar)")
+        token = scanner.get_token
+        token.should == ["fstatement", "foo(bar)"]
+      end
+
       it "should identify a function statement with multiple parameters" do
         scanner = Scanner.new("foo('bar','baz')")
         token = scanner.get_token
@@ -97,12 +109,6 @@ module MCollective
 
       it "should identify a bad token where there is only one forward slash after a comparison operator" do
         scanner = Scanner.new("foo=/bar")
-        token = scanner.get_token
-        token.should == ["bad_token", [0,7]]
-      end
-
-      it "should identify a bad token where function parameters are not in single quotes" do
-        scanner = Scanner.new("foo(bar)")
         token = scanner.get_token
         token.should == ["bad_token", [0,7]]
       end


### PR DESCRIPTION
Allows function arguments to be unquoted, as in `fact(os.family)`.