### PR TITLE
(MCO-818) Use native array maths to calculate responses

### DIFF
--- a/lib/mcollective/rpc/stats.rb
+++ b/lib/mcollective/rpc/stats.rb
@@ -118,14 +118,10 @@ module MCollective
         @totaltime = @blocktime + @discoverytime
 
         # figure out who responded unexpectedly
-        rhosts = @responsesfrom.clone
-        @discovered_nodes.each {|d| rhosts.delete(d)}
-        @unexpectedresponsefrom = rhosts
+        @unexpectedresponsefrom = @responsesfrom - @discovered_nodes
 
         # figure out who we had no responses from
-        dhosts = @discovered_nodes.clone
-        @responsesfrom.each {|r| dhosts.delete(r)}
-        @noresponsefrom = dhosts
+        @noresponsefrom = @discovered_nodes - @responsesfrom
       rescue
         @totaltime = 0
         @noresponsefrom = []


### PR DESCRIPTION
Instead of the extremely slow looping over every result use the built in
array maths to calculate nodes that did not respond and unexpected
responses