### PR TITLE
(MCO-820) Allow default batch options to be set

### DIFF
--- a/lib/mcollective/config.rb
+++ b/lib/mcollective/config.rb
@@ -17,7 +17,7 @@ module MCollective
     attr_reader :default_discovery_method, :default_discovery_options
     attr_reader :publish_timeout, :threaded, :soft_shutdown, :activate_agents
     attr_reader :registration_splay, :discovery_timeout, :soft_shutdown_timeout
-    attr_reader :connection_timeout
+    attr_reader :connection_timeout, :default_batch_size, :default_batch_sleep_time
 
     def initialize
       @configured = false
@@ -125,6 +125,10 @@ module MCollective
                   @soft_shutdown_timeout = Integer(val)
                 when "activate_agents"
                   @activate_agents = Util.str_to_bool(val)
+                when "default_batch_size"
+                  @default_batch_size = Integer(val)
+                when "default_batch_sleep_time"
+                  @default_batch_sleep_time = Float(val)
                 when "topicprefix", "topicsep", "queueprefix", "rpchelptemplate", "helptemplatedir"
                   Log.warn("Use of deprecated '#{key}' option.  This option is ignored and should be removed from '#{configfile}'")
                 else
@@ -212,6 +216,8 @@ module MCollective
       @soft_shutdown_timeout = nil
       @activate_agents = true
       @connection_timeout = nil
+      @default_batch_size = 0
+      @default_batch_sleep_time = 1
     end
 
     def libdir

--- a/lib/mcollective/rpc/client.rb
+++ b/lib/mcollective/rpc/client.rb
@@ -71,8 +71,8 @@ module MCollective
         @discovery_options = initial_options[:discovery_options] || []
         @force_display_mode = initial_options[:force_display_mode] || false
 
-        @batch_size = initial_options[:batch_size] || 0
-        @batch_sleep_time = Float(initial_options[:batch_sleep_time] || 1)
+        @batch_size = initial_options[:batch_size] || Config.instance.default_batch_size
+        @batch_sleep_time = Float(initial_options[:batch_sleep_time] || Config.instance.default_batch_sleep_time)
         @batch_mode = determine_batch_mode(@batch_size)
 
         agent_filter agent

--- a/spec/unit/mcollective/rpc/client_spec.rb
+++ b/spec/unit/mcollective/rpc/client_spec.rb
@@ -156,6 +156,18 @@ module MCollective
           c = Client.new("rspec", :options => {:config => "/nonexisting", :disctimeout => 10})
           c.instance_variable_get("@discovery_timeout").should == 10
         end
+
+        it "should default to configured batch options" do
+          expect(@client.batch_size).to eq(0)
+          expect(@client.batch_sleep_time).to eq(1)
+
+          Config.instance.stubs(:default_batch_size).returns(1000)
+          Config.instance.stubs(:default_batch_sleep_time).returns(30)
+          c = Client.new("rspec", :options => {})
+
+          expect(c.batch_size).to eq(1000)
+          expect(c.batch_sleep_time).to eq(30)
+        end
       end
 
       describe "#validate_request" do

--- a/website/reference/basic/configuration.md
+++ b/website/reference/basic/configuration.md
@@ -18,7 +18,7 @@ You can configure the MCollective server daemon and client by setting options in
 
 ## Configuration Files
 
-MCollective uses two configuration files, one for the client and one for the server. 
+MCollective uses two configuration files, one for the client and one for the server.
 
 If you don't specify a client configuration file when invoking MCollective, it looks for one in these locations, in the listed order:
 
@@ -90,6 +90,8 @@ The client configuration file should be globally readable.
 |color|0|Disables the use of color in RPC results|
 |connection_timeout|3|Sets the timeout for server communication. Default: none|
 |discovery_timeout|2|Sets the timeout for discovering nodes. Default: 2|
+|default_batch_size|100|Sets the default batch size which would be used when when not supplied in the API or CLI. Default 0|
+|default_batch_sleep_time|30|Sets the default batch sleep time which would be used when when not supplied in the API or CLI. Default 1|
 
 ## Plugin Configuration
 
@@ -111,7 +113,7 @@ Common plugin options include:
 
 ## Client Setup
 
-Do not set the host, user, password, and pre-shared key in the client configuration file, since these files are generally world-readable (unlike the server configuration file, which should be readable by the root user only). 
+Do not set the host, user, password, and pre-shared key in the client configuration file, since these files are generally world-readable (unlike the server configuration file, which should be readable by the root user only).
 
 > **Note:** You can make this clearer by explicitly setting these options to 'unset' in the client configuration file, which prevents MCollective from working unless something overrides those settings.
 


### PR DESCRIPTION
In order to allow admins to protect themselves from accidents by users
who forget to specify batch options this allows the admins to configure
`default_batch_size` and `default_batch_sleep_time` in the client config
which would then always be active when not otherwise specified