### PR TITLE
(maint) Update acceptance tests that reference nightlies

### DIFF
--- a/acceptance/lib/puppet/acceptance/install_utils.rb
+++ b/acceptance/lib/puppet/acceptance/install_utils.rb
@@ -119,7 +119,7 @@ module Puppet
       def install_repos_on(host, project, sha, repo_configs_dir)
         platform = host['platform'].with_version_codename
         platform_configs_dir = File.join(repo_configs_dir,platform)
-        tld     = sha == 'nightly' ? 'nightlies.puppetlabs.com' : 'builds.puppetlabs.lan'
+        tld     = sha == 'nightly' ? 'ravi.puppetlabs.com' : 'builds.puppetlabs.lan'
         project = sha == 'nightly' ? project + '-latest'        :  project
         sha     = sha == 'nightly' ? nil                        :  sha
 


### PR DESCRIPTION
This commit changes the name of the nightlies server to the actual hostname so that when we remove the 'nightlies' cname (to use for *new* nightlies), tests won't break. THIS SHOULD NOT BE PERMANENT (see RE-10231).