### PR TITLE
(packaging) Update reported version to 2.12.0

### DIFF
--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="2.11.4"
+  VERSION="2.12.0"
 
   def self.version
     VERSION


### PR DESCRIPTION
This is a preemptive reported version bump in advance of the puppet agent 5.5.0 release.