### PR TITLE
(MCO-328) Actually use the implemented signal

### DIFF
--- a/ext/aio/redhat/mcollective-systemd.logrotate
+++ b/ext/aio/redhat/mcollective-systemd.logrotate
@@ -3,6 +3,6 @@
     notifempty
     sharedscripts
     postrotate
-      systemctl restart mcollective >/dev/null 2>&1 || true
+      if [ systemctl status mcollective.service > /dev/null 2>&1 ]; then systemctl kill --signal=WINCH --kill-who=main mcollective.service; fi
     endscript
 }

--- a/ext/aio/redhat/mcollective-sysv.logrotate
+++ b/ext/aio/redhat/mcollective-sysv.logrotate
@@ -3,6 +3,6 @@
     notifempty
     sharedscripts
     postrotate
-        /etc/init.d/mcollective restart >/dev/null 2>&1 || true
+        /etc/init.d/mcollective reopen-logfile >/dev/null 2>&1 || true
     endscript
 }

--- a/ext/aio/redhat/mcollective.init
+++ b/ext/aio/redhat/mcollective.init
@@ -100,6 +100,14 @@ reload_loglevel() {
     return $RETVAL
 }
 
+reopen_logfile() {
+    echo -n "Re-opening mcollective log file: "
+    killproc ${pidopts} ${mcollectived} -SIGWINCH
+    RETVAL=$?
+    echo
+    return $RETVAL
+}
+
 rh_status() {
     status ${pidopts} ${mcollectived}
     RETVAL=$?
@@ -130,6 +138,9 @@ case "$1" in
         ;;
     reload-loglevel)
         reload_loglevel
+        ;;
+    reopen-logfile)
+        reopen_logfile
         ;;
     status)
         rh_status


### PR DESCRIPTION
Logrotate should ask mcollective to reopen its logfile, not restart the whole service.

Apparently we never actually did this after implementing the signal support???