### PR TITLE
(MCO-832) Include offset from UTC in log messages

### DIFF
--- a/lib/mcollective.rb
+++ b/lib/mcollective.rb
@@ -59,7 +59,7 @@ module MCollective
 
   MCollective::Vendor.load_vendored
 
-  VERSION="2.12.0"
+  VERSION="2.13.0"
 
   def self.version
     VERSION

--- a/lib/mcollective/logger/file_logger.rb
+++ b/lib/mcollective/logger/file_logger.rb
@@ -15,6 +15,8 @@ module MCollective
 
         @logger = ::Logger.new(config.logfile, config.keeplogs, config.max_log_size)
         @logger.formatter = ::Logger::Formatter.new
+        # ISO-8601 with sub-second precision and offset from UTC.
+        @logger.formatter.datetime_format = "%Y-%m-%dT%H:%M:%S.%6N%:z "
 
         set_level(config.loglevel.to_sym)
       end

--- a/spec/unit/mcollective/logger/file_logger_spec.rb
+++ b/spec/unit/mcollective/logger/file_logger_spec.rb
@@ -8,6 +8,7 @@ module MCollective
   module Logger
     describe File_logger do
       let(:mock_logger) { mock('logger') }
+      let(:mock_formatter) { mock('formatter') }
 
       before :each do
         Config.instance.stubs(:loglevel).returns("error")
@@ -17,6 +18,9 @@ module MCollective
         ::Logger.stubs(:new).returns(mock_logger)
         mock_logger.stubs(:formatter=)
         mock_logger.stubs(:level=)
+
+        mock_logger.stubs(:formatter).returns(mock_formatter)
+        mock_formatter.stubs(:datetime_format=)
       end
 
       describe "#start" do


### PR DESCRIPTION
This commit updates the format used by the File_logger to include the offset
from UTC in the timestamp added to the log messages. This context helps with
troubleshooting issues that arise when the client, server, and broker are
operating in different time zones.