### PR TITLE
(MCO-803) Log unexpected STOMP frames at WARN level

### DIFF
--- a/lib/mcollective/connector/activemq.rb
+++ b/lib/mcollective/connector/activemq.rb
@@ -437,7 +437,7 @@ module MCollective
 
         # We expect all messages we get to be of STOMP frame type MESSAGE, raise on unexpected types
         if msg.command != 'MESSAGE'
-          Log.debug("Unexpected '#{msg.command}' frame.  Headers: #{msg.headers.inspect} Body: #{msg.body.inspect}")
+          Log.warn("Unexpected '#{msg.command}' frame.  Headers: #{msg.headers.inspect} Body: #{msg.body.inspect}")
           raise UnexpectedMessageType.new(exponential_back_off),
             "Received frame of type '#{msg.command}' expected 'MESSAGE'"
         end

--- a/spec/unit/mcollective/connector/activemq_spec.rb
+++ b/spec/unit/mcollective/connector/activemq_spec.rb
@@ -412,8 +412,8 @@ module MCollective
 
           Message.stubs(:new)
 
-          Log.stubs(:debug)
-          Log.expects(:debug).with('Unexpected \'ERROR\' frame.  Headers: "headers" Body: "Out of cheese exception"')
+          Log.stubs(:warn)
+          Log.expects(:warn).with('Unexpected \'ERROR\' frame.  Headers: "headers" Body: "Out of cheese exception"')
 
           expect { connector.receive }.to raise_error(UnexpectedMessageType, /Received frame of type 'ERROR' expected 'MESSAGE'/)
         end


### PR DESCRIPTION
We raise an error message if a STOMP frame with a type other than MESSAGE is
received. Details about the frame are logged at debug level, which means they
never actually make it into the logs on a normal system. The content of these
frames can include important information about broker health. This commit
increases the log level from DEBUG to WARN so that this information is captured
alongside the error message.