### PR TITLE
(MCO-833) Fix loading facts when YAML file contains aliases

### DIFF
--- a/lib/mcollective/facts/yaml_facts.rb
+++ b/lib/mcollective/facts/yaml_facts.rb
@@ -24,7 +24,7 @@ module MCollective
           begin
             if File.exist?(file)
 	      if YAML.respond_to? :safe_load
-                facts.merge!(YAML.safe_load(File.read(file))) 
+                facts.merge!(YAML.safe_load(File.read(file), [Symbol], [], true))
 	      else
                 facts.merge!(YAML.load(File.read(file)))  # rubocop:disable Security/YAMLLoad
               end


### PR DESCRIPTION
If YAML.safe_load is in use, we need to explicity enable aliases. This
is needed for example by choria-mcollective which is creating
aliases for `libdir`.