### PR TITLE
(maint) Use rspec spec in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: ruby
-script: "bundle exec rake $CHECK"
+script: 'bundle exec rspec spec'
 notifications:
   email: false
 rvm:
@@ -11,18 +11,9 @@ rvm:
   - 1.9.3
   - 1.8.7
 env:
-  - "CHECK=test"
-  - "CHECK=rubocop"
-
+  - NAME=rspec
 matrix:
-  exclude:
-    - rvm: 2.2.5
-      env: "CHECK=rubocop"
-    - rvm: 2.1.9
-      env: "CHECK=rubocop"
-    - rvm: 2.0.0
-      env: "CHECK=rubocop"
-    - rvm: 1.9.3
-      env: "CHECK=rubocop"
-    - rvm: 1.8.7
-      env: "CHECK=rubocop"
+  include:
+    - env: NAME=rubocop
+      rvm: 2.3.1
+      script: 'bundle exec rake rubocop'


### PR DESCRIPTION
To bump to newer versions of rake, we need to stop using it to run rspec
because rspec 2 and rake 12 are incompatible.