### PR TITLE
(maint) Use beaker 4 by default in acceptance

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -12,7 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 3.6")
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || "~> 4")
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.8")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.2")
 gem "rake"


### PR DESCRIPTION
These versions reflect what's being used in CI now.