### PR TITLE
(PA-2878) mcollective.service wrong PID

### DIFF
--- a/ext/aio/redhat/mcollective.service
+++ b/ext/aio/redhat/mcollective.service
@@ -16,9 +16,9 @@ After=network.target
 Type=forking
 StandardOutput=syslog
 StandardError=syslog
-ExecStart=/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --pidfile=/var/run/puppetlabs/mcollective.pid --daemonize
+ExecStart=/opt/puppetlabs/puppet/bin/mcollectived --config=/etc/puppetlabs/mcollective/server.cfg --pidfile=/run/puppetlabs/mcollective.pid --daemonize
 ExecReload=/bin/kill -USR1 $MAINPID
-PIDFile=/var/run/puppetlabs/mcollective.pid
+PIDFile=/run/puppetlabs/mcollective.pid
 KillMode=process
 
 [Install]

--- a/ext/redhat/mcollective.service
+++ b/ext/redhat/mcollective.service
@@ -16,9 +16,9 @@ After=network.target
 Type=simple
 StandardOutput=syslog
 StandardError=syslog
-ExecStart=/usr/sbin/mcollectived --config=/etc/mcollective/server.cfg --pidfile=/var/run/mcollective.pid --no-daemonize
+ExecStart=/usr/sbin/mcollectived --config=/etc/mcollective/server.cfg --pidfile=/run/mcollective.pid --no-daemonize
 ExecReload=/bin/kill -USR1 $MAINPID
-PIDFile=/var/run/mcollective.pid
+PIDFile=/run/mcollective.pid
 KillMode=process
 
 [Install]


### PR DESCRIPTION
This commit fixes the pidfile location in mcollective.service that causes
an unnecessary log to appear in systemctl